### PR TITLE
Add app to automatically update dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Build output
+[Bb]in/
+[Oo]bj/
+
+# DNX
+project.lock.json
+artifacts/
+
+# dotnet install directory
+.dotnet/
+
+ # Visual Studio 2015 cache/options directory
+.vs/
+
+# Visual Studio Code cache/options directory
+.vscode/
+
+# User-specific files
+*.suo
+*.user

--- a/update-dependencies/Config.cs
+++ b/update-dependencies/Config.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dotnet.Docker.Nightly
+{
+    public class Config
+    {
+        public static Config s_Instance { get; } = new Config();
+
+        private Lazy<string> _userName = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_USER"));
+        private Lazy<string> _email = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_EMAIL"));
+        private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
+        
+        private Lazy<string> _cliVersionUrl = new Lazy<string>(() => $"https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/cli/{GetEnvironmentVariable("CLI_BRANCH")}");
+        private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
+        private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "dotnet-docker-nightly"));
+        private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "master"));
+        private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() => 
+                                                GetEnvironmentVariable("GITHUB_PULL_REQUEST_NOTIFICATIONS", "")
+                                                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+
+        private Config()
+        {
+        }
+
+        public string UserName => _userName.Value;
+        public string Email => _email.Value; 
+        public string Password => _password.Value;
+        public string CliVersionUrl => _cliVersionUrl.Value;
+        public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
+        public string GitHubProject => _gitHubProject.Value;
+        public string GitHubUpstreamBranch => _gitHubUpstreamBranch.Value;
+        public string[] GitHubPullRequestNotifications => _gitHubPullRequestNotifications.Value;
+
+        private static string GetEnvironmentVariable(string name, string defaultValue = null)
+        {
+            string value = Environment.GetEnvironmentVariable(name);
+            if (value == null)
+            {
+                value = defaultValue;
+            }
+
+            if (value == null)
+            {
+                throw new InvalidOperationException($"Can't find environment variable '{name}'.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/update-dependencies/NuGet.config
+++ b/update-dependencies/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Dotnet.Docker.Nightly
+{
+    public static class Program
+    {
+        private static readonly string s_repoRoot = Directory.GetCurrentDirectory();
+        private static readonly Config s_config = Config.s_Instance;
+        private static bool s_updateOnly = false;
+
+        public static void Main(string[] args)
+        {
+            if (ParseArgs(args))
+            {
+                DependencyUpdateResults updateResults = UpdateFiles();
+
+                if (!s_updateOnly && updateResults.ChangesDetected())
+                {
+                    CreatePullRequest(updateResults).Wait();
+                }
+            }
+        }
+        
+        private static bool ParseArgs(string[] args)
+        {
+            foreach (string arg in args)
+            {
+                if (string.Equals(arg, "--Update", StringComparison.OrdinalIgnoreCase))
+                {
+                    s_updateOnly = true;
+                }
+                else if (arg.Contains('='))
+                {
+                    int delimiterIndex = arg.IndexOf('=');
+                    string name = arg.Substring(0, delimiterIndex);
+                    string value = arg.Substring(delimiterIndex + 1);
+
+                    Environment.SetEnvironmentVariable(name, value);
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Unrecognized argument '{arg}'");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static DependencyUpdateResults UpdateFiles()
+        {
+            // The BuildInfo does not contain the CLI product version, so the version is retrieved from a
+            // particular CLI package (e.g. Microsoft.DotNet.Cli.Utils). Once the BuildInfo includes the
+            // product version, it should be utilized.
+            //
+            // This app does not update the version of the .NET Core runtime/framework in the Dockerfiles
+            // because the infrastructure is not in place to retrieve the version on which the SDK depends.
+            // This version is infrequently updated, so this is acceptable for now, but once the
+            // infrastructure is in place, this app should update the runtime/framework version also.
+
+            IEnumerable<BuildInfo> buildInfos = new[] { BuildInfo.Get("Cli", s_config.CliVersionUrl, fetchLatestReleaseFile: false) };
+            IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
+
+            DependencyUpdater updater = new DependencyUpdater();
+            return updater.Update(updaters, buildInfos);
+        }
+
+        private static Task CreatePullRequest(DependencyUpdateResults updateResults)
+        {
+            string commitMessage = $"Update SDK to {updateResults.UsedBuildInfos.Single().LatestReleaseVersion}";
+
+            GitHubAuth gitHubAuth = new GitHubAuth(s_config.Password, s_config.UserName, s_config.Email);
+
+            PullRequestCreator prCreator = new PullRequestCreator(
+                gitHubAuth,
+                s_config.GitHubProject,
+                s_config.GitHubUpstreamOwner,
+                s_config.GitHubUpstreamBranch,
+                s_config.UserName
+            );
+
+            return prCreator.CreateOrUpdateAsync(commitMessage, commitMessage, string.Empty);
+        }
+
+        private static IEnumerable<IDependencyUpdater> GetUpdaters()
+        {
+            return Directory.GetFiles(s_repoRoot, "Dockerfile", SearchOption.AllDirectories)
+                .Select(path => CreateRegexUpdater(path, "Microsoft.DotNet.Cli.Utils"));
+        }
+
+        private static IDependencyUpdater CreateRegexUpdater(string path, string packageId)
+        {
+            return new FileRegexPackageUpdater()
+            {
+                Path = path,
+                PackageId = packageId,
+                Regex = new Regex($@"ENV DOTNET_SDK_VERSION (?<version>.*)"),
+                VersionGroupName = "version"
+            };
+        }
+    }
+}

--- a/update-dependencies/project.json
+++ b/update-dependencies/project.json
@@ -1,0 +1,29 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "Microsoft.NETCore.App": "1.0.0",
+    "Microsoft.DotNet.VersionTools": "1.0.26-prerelease-00708-05"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {}
+  },
+
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.10-x64": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
+    "centos.7-x64": {},
+    "rhel.7.2-x64": {},
+    "debian.8-x64": {},
+    "fedora.23-x64": {},
+    "opensuse.13.2-x64": {}
+  }
+}

--- a/update-dependencies/update-dependencies.ps1
+++ b/update-dependencies/update-dependencies.ps1
@@ -1,0 +1,65 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+param(
+    [string]$CliBranch="rel/1.0.0",
+    [string]$DotnetInstallDir,
+    [string[]]$EnvVars=@(),
+    [switch]$Help)
+
+if($Help)
+{
+    Write-Host "Usage: .\update-dependencies.ps1 [Options]"
+    Write-Host ""
+    Write-Host "Summary: Installs the .NET Core SDK and then compiles and runs update-dependencies.exe."
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -CliBranch <branch_name>           The dotnet/cli branch to use for installing the .NET SDK. Defaults to 'rel/1.0.0'."
+    Write-Host "  -DotnetInstallDir <path>           The directory in which to install the .NET SDK. Defaults to '`$RepoRoot\.dotnet\Windows\`$Architecture'."
+    Write-Host "  -EnvVars <'V1=val1','V2=val2'...>  Comma separated list of environment variable name-value pairs"
+    Write-Host "  -Help                              Display this help message"
+    exit 0
+}
+
+$Architecture='x64'
+
+$RepoRoot = "$PSScriptRoot\.."
+$AppPath = "$PSScriptRoot"
+
+if ([string]::IsNullOrWhiteSpace($DotnetInstallDir))
+{
+    $DotnetInstallDir = "$RepoRoot\.dotnet\Windows\$Architecture"
+}
+
+if (!(Test-Path "$RepoRoot\artifacts"))
+{
+    mkdir "$RepoRoot\artifacts" | Out-Null
+}
+
+# Install the .NET Core SDK
+$DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/$CliBranch/scripts/obtain/dotnet-install.ps1"
+Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile "$RepoRoot\artifacts\dotnet-install.ps1"
+
+& "$RepoRoot\artifacts\dotnet-install.ps1" -Architecture $Architecture -InstallDir $DotnetInstallDir
+if($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
+
+ # Restore the app 
+Write-Host "Restoring app $AppPath..."
+pushd "$AppPath"
+dotnet restore
+if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
+popd
+
+# Publish the app
+Write-Host "Compiling app..."
+dotnet publish "$AppPath" -o "$AppPath\bin" --framework netcoreapp1.0
+if($LASTEXITCODE -ne 0) { throw "Failed to compile" }
+
+# Run the app
+Write-Host "Invoking app: $AppPath\bin\update-dependencies.exe $EnvVars"
+pushd $RepoRoot
+& "$AppPath\bin\update-dependencies.exe" @EnvVars
+if($LASTEXITCODE -ne 0) { throw "App execution failed" }
+popd

--- a/update-dependencies/update-dependencies.xproj
+++ b/update-dependencies/update-dependencies.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2c9d9a88-6e8c-4be0-9506-9d992d22423f</ProjectGuid>
+    <RootNamespace>Dotnet.Docker.Nightly</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>


### PR DESCRIPTION
The update-dependencies .NET app must be invoked from the root of the
repo.  A update-dependencies.ps1 script is also provided which installs
the .NET CLI and then compiles and invokes the app; this script can be
invoked from anywhere.

The plan is for Maestro to invoke a VSTS build definition whenever a new
CLI build is available, which will invoke the update-dependencies.ps1
script.

Also add a .gitignore file.

cc: @MichaelSimons 