### PR TITLE
Fix regex to handle CRLF line endings

### DIFF
--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Dependencies;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -21,6 +22,8 @@ namespace Dotnet.Docker.Nightly
 
         public static void Main(string[] args)
         {
+            Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
+
             if (ParseArgs(args))
             {
                 DependencyUpdateResults updateResults = UpdateFiles();
@@ -105,7 +108,7 @@ namespace Dotnet.Docker.Nightly
             {
                 Path = path,
                 PackageId = packageId,
-                Regex = new Regex($@"ENV DOTNET_SDK_VERSION (?<version>.*)"),
+                Regex = new Regex($@"ENV DOTNET_SDK_VERSION (?<version>[^\r\n]*)"),
                 VersionGroupName = "version"
             };
         }

--- a/update-dependencies/project.json
+++ b/update-dependencies/project.json
@@ -6,7 +6,8 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": "1.0.0",
-    "Microsoft.DotNet.VersionTools": "1.0.26-prerelease-00708-05"
+    "Microsoft.DotNet.VersionTools": "1.0.26-prerelease-00708-05",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
The regex pattern for the DOTNET_SDK_VERSION was including \r in its
matches, causing the \r to be removed from that line when the version
string was replaced. This is because by default the '.' language element
matches every character except \n. The fix is to explicitly match every
character except \r and \n so that the pattern matches don't include \r.

This change also adds a Trace Listener so that useful output from
VersionTools is captured in the output of the app.

cc: @MichaelSimons @dagood 