### PR TITLE
Add Jenkins CI and automated tests for Debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ artifacts/
 # dotnet install directory
 .dotnet/
 
+# test assets
+.test-assets/
+
  # Visual Studio 2015 cache/options directory
 .vs/
 

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+set -o pipefail  # Carry failures over pipes
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+docker_repo="microsoft/dotnet-nightly"
+
+function build_dockerfiles {
+    for dockerfile_dir in $( egrep -v 'nanoserver|windowsservercore' <<< "${1}" | sort ); do
+        tag="${docker_repo}:$( sed -e 's/.\///' -e 's/debian\///' -e 's/debian/sdk/' -e 's/\//-/g' <<< "${dockerfile_dir}" )"
+        echo "----- Building ${tag} -----"
+        docker build -t "${tag}" "${dockerfile_dir}"
+    done
+}
+
+pushd "${repo_root}" > /dev/null
+
+build_dockerfiles "$( find . -path './.*' -prune -o -name 'Dockerfile' -a -path '*/*-deps/*' -print0 | xargs -0 -n1 dirname )"
+
+build_dockerfiles "$( find . -path './.*' -prune -o -name 'Dockerfile' -a ! -path '*/*-deps/*' -print0 | xargs -0 -n1 dirname)"
+
+popd > /dev/null
+
+"${repo_root}/test/run-test.sh"

--- a/netci.groovy
+++ b/netci.groovy
@@ -1,0 +1,17 @@
+import jobs.generation.Utilities
+
+def project = GithubProject
+def branch = GithubBranchName
+def isPr = true
+def containerOs = 'Debian'
+def newJobName = Utilities.getFullJobName(project, containerOs, isPr)
+
+def newJob = job(newJobName) {
+    steps {
+        shell(".build-and-test.sh")
+    }
+}
+
+Utilities.setMachineAffinity(newJob, 'Ubuntu16.04', 'latest-or-auto-docker')
+Utilities.standardJobSetup(newJob, project, isPr, "*/${branch}")
+Utilities.addGithubPRTriggerForBranch(newJob, branch, containerOs)

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+
+: ${1?"Need to pass sandbox directory as argument"}
+
+cd $1
+dotnet new
+dotnet restore
+dotnet run
+dotnet publish -o publish

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e 	# Exit immediately upon failure
+set -o pipefail  # Carry failures over pipes
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+docker_repo="microsoft/dotnet-nightly"
+
+if [ -z "${DEBUGTEST}" ]; then
+    optional_docker_run_args="--rm"
+fi
+
+pushd "${repo_root}" > /dev/null
+
+for cli_channel in $( find . -mindepth 1 -maxdepth 1 -type d ! -name '.*' ! -name 'test' ! -name 'update-dependencies' -print | sed -e 's/\.\///' ); do
+    tag_base="${docker_repo}:${cli_channel}"
+
+    app_name="app$(date +%s)"
+    app_dir="${repo_root}/.test-assets/${app_name}"
+    mkdir -p "${app_dir}"
+
+    echo "----- Testing ${tag_base}-sdk -----"
+    docker run -t "${optional_docker_run_args}" -v "${app_dir}:/${app_name}" -v "${repo_root}/test:/test" --name "sdk-test-${app_name}" --entrypoint /test/create-run-publish-app.sh "${tag_base}-sdk" "${app_name}"
+
+    echo "----- Testing ${tag_base}-core -----"
+    docker run -t "${optional_docker_run_args}" -v "${app_dir}:/${app_name}" --name "core-test-${app_name}" --entrypoint dotnet "${tag_base}-core" "/${app_name}/publish/${app_name}.dll"
+
+    echo "----- Testing ${tag_base}-onbuild -----"
+    pushd "${app_dir}" > /dev/null
+    echo "FROM ${tag_base}-onbuild" > Dockerfile
+    docker build -t "${app_name}-onbuild" .
+    popd > /dev/null
+    docker run -t "${optional_docker_run_args}" --name "onbuild-test-${app_name}" "${app_name}-onbuild"
+
+    if [ -z "${DEBUGTEST}" ]; then
+        docker rmi "${app_name}-onbuild"
+    fi
+done
+
+popd > /dev/null


### PR DESCRIPTION
Whenever a PR is created in the dev or master branch, a Jenkins job will
build each Debian Dockerfile and run tests.  The tests perform a simple
smoke test on the images.

In this initial implementation, only the Debian images are built and
tested.  The plan is to eventually test the Windows Server images also.

/cc: @MichaelSimons @mmitche 