### PR TITLE
Disable CI on Windows

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -3,7 +3,7 @@ import jobs.generation.Utilities
 def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
-def platformList = ['Ubuntu16.04:Debian', 'Windows_2016:WindowsServerCore', 'Windows Nano 2016:NanoServer']
+def platformList = ['Ubuntu16.04:Debian'/*, 'Windows_2016:WindowsServerCore', 'Windows Nano 2016:NanoServer'*/]
 
 platformList.each { platform ->
     def(hostOS, containerOS) = platform.tokenize(':')


### PR DESCRIPTION
Disabling CI on Windows for the time being given issues with getting machines configured correctly to run CI on.

cc @naamunds 