### PR TITLE
Add CI for core-deps images

### DIFF
--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -4,7 +4,22 @@ set -e 	# Exit immediately upon failure
 : ${1?"Need to pass sandbox directory as argument"}
 
 cd $1
+
+echo "Testing framework-dependent deployment"
 dotnet new
 dotnet restore
 dotnet run
-dotnet publish -o publish
+dotnet publish -o publish/framework-dependent
+
+echo "Testing self-contained deployment"
+cp project.json project.json.bak
+runtimes_section="  },\n  \"runtimes\": {\n    \"debian.8-x64\": {}\n  }"
+sed -i '/"type": "platform"/d' ./project.json
+sed -i "s/^  }$/${runtimes_section}/" ./project.json
+
+dotnet restore
+dotnet run
+dotnet publish -o publish/self-contained
+
+# Restore project.json to specify framework-dependent deployment for the onbuild image test
+mv -f project.json.bak project.json

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -39,17 +39,17 @@ for development_image_version in $( find . -path './.*' -prune -o -path '*/debia
     mkdir -p "${app_dir}"
 
     echo "----- Testing ${development_tag_base}-sdk -----"
-    docker run -t "${optional_docker_run_args}" -v "${app_dir}:/${app_name}" -v "${repo_root}/test:/test" --name "sdk-test-${app_name}" --entrypoint /test/create-run-publish-app.sh "${development_tag_base}-sdk" "${app_name}"
+    docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" -v "${repo_root}/test:/test" --name "sdk-test-${app_name}" --entrypoint /test/create-run-publish-app.sh "${development_tag_base}-sdk" "${app_name}"
 
     echo "----- Testing ${runtime_tag_base}-core -----"
-    docker run -t "${optional_docker_run_args}" -v "${app_dir}:/${app_name}" --name "core-test-${app_name}" --entrypoint dotnet "${runtime_tag_base}-core" "/${app_name}/publish/${app_name}.dll"
+    docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" --name "core-test-${app_name}" --entrypoint dotnet "${runtime_tag_base}-core" "/${app_name}/publish/${app_name}.dll"
 
     echo "----- Testing ${development_tag_base}-onbuild -----"
     pushd "${app_dir}" > /dev/null
     echo "FROM ${development_tag_base}-onbuild" > Dockerfile
     docker build -t "${app_name}-onbuild" .
     popd > /dev/null
-    docker run -t "${optional_docker_run_args}" --name "onbuild-test-${app_name}" "${app_name}-onbuild"
+    docker run -t ${optional_docker_run_args} --name "onbuild-test-${app_name}" "${app_name}-onbuild"
 
     if [ -z "${DEBUGTEST}" ]; then
         docker rmi "${app_name}-onbuild"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -42,7 +42,10 @@ for development_image_version in $( find . -path './.*' -prune -o -path '*/debia
     docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" -v "${repo_root}/test:/test" --name "sdk-test-${app_name}" --entrypoint /test/create-run-publish-app.sh "${development_tag_base}-sdk" "${app_name}"
 
     echo "----- Testing ${runtime_tag_base}-core -----"
-    docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" --name "core-test-${app_name}" --entrypoint dotnet "${runtime_tag_base}-core" "/${app_name}/publish/${app_name}.dll"
+    docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" --name "core-test-${app_name}" --entrypoint dotnet "${runtime_tag_base}-core" "/${app_name}/publish/framework-dependent/${app_name}.dll"
+
+    echo "----- Testing ${runtime_tag_base}-core-deps -----"
+    docker run -t ${optional_docker_run_args} -v "${app_dir}:/${app_name}" --name "core-deps-test-${app_name}" --entrypoint "/${app_name}/publish/self-contained/${app_name}" "${runtime_tag_base}-core-deps"
 
     echo "----- Testing ${development_tag_base}-onbuild -----"
     pushd "${app_dir}" > /dev/null


### PR DESCRIPTION
Test core-deps by creating a self-contained app in the sdk container,
and then running the self-contained app's published executable in a
core-deps container.

Also fix running with DEBUGTEST by putting the trailing space in
"optional_docker_run_args" instead of in the "docker run" commands to
eliminate the two consecutive spaces.

This PR is porting https://github.com/dotnet/dotnet-docker/pull/118 to this repo.

cc: @MichaelSimons