### PR TITLE
Update onbuild - remove 'run'

### DIFF
--- a/rel-1.0.0-preview2.1/debian/onbuild/Dockerfile
+++ b/rel-1.0.0-preview2.1/debian/onbuild/Dockerfile
@@ -1,9 +1,10 @@
 FROM microsoft/dotnet-nightly:rel-1.0.0-preview2.1-sdk
 
-RUN mkdir -p /dotnetapp
 WORKDIR /dotnetapp
 
-ENTRYPOINT ["dotnet", "run"]
+ENTRYPOINT ["dotnet", "out/dotnetapp.dll"]
 
-ONBUILD COPY . /dotnetapp
+ONBUILD COPY project.json ./
 ONBUILD RUN dotnet restore
+ONBUILD COPY . ./
+ONBUILD RUN dotnet publish -c Release -o out

--- a/rel-1.0.0-preview2.1/nanoserver/onbuild/Dockerfile
+++ b/rel-1.0.0-preview2.1/nanoserver/onbuild/Dockerfile
@@ -1,9 +1,10 @@
 FROM microsoft/dotnet-nightly:rel-1.0.0-preview2.1-nanoserver-sdk
 
-RUN mkdir dotnetapp
-WORKDIR dotnetapp
+WORKDIR /dotnetapp
 
-ENTRYPOINT ["dotnet", "run"]
+ENTRYPOINT ["dotnet", "out/dotnetapp.dll"]
 
-ONBUILD COPY . .
+ONBUILD COPY project.json ./
 ONBUILD RUN dotnet restore
+ONBUILD COPY . ./
+ONBUILD RUN dotnet publish -c Release -o out

--- a/rel-1.0.0/debian/onbuild/Dockerfile
+++ b/rel-1.0.0/debian/onbuild/Dockerfile
@@ -1,9 +1,11 @@
 FROM microsoft/dotnet-nightly:rel-1.0.0-sdk
 
-RUN mkdir -p /dotnetapp
 WORKDIR /dotnetapp
 
-ENTRYPOINT ["dotnet", "run"]
+ENTRYPOINT ["dotnet", "out/dotnetapp.dll"]
 
-ONBUILD COPY . /dotnetapp
+ONBUILD COPY project.json ./
 ONBUILD RUN dotnet restore
+ONBUILD COPY . ./
+ONBUILD RUN dotnet publish -c Release -o out
+

--- a/rel-1.0.0/nanoserver/onbuild/Dockerfile
+++ b/rel-1.0.0/nanoserver/onbuild/Dockerfile
@@ -1,9 +1,10 @@
 FROM microsoft/dotnet-nightly:rel-1.0.0-nanoserver-sdk
 
-RUN mkdir dotnetapp
-WORKDIR dotnetapp
+WORKDIR /dotnetapp
 
-ENTRYPOINT ["dotnet", "run"]
+ENTRYPOINT ["dotnet", "out/dotnetapp.dll"]
 
-ONBUILD COPY . .
+ONBUILD COPY project.json ./
 ONBUILD RUN dotnet restore
+ONBUILD COPY . ./
+ONBUILD RUN dotnet publish -c Release -o out


### PR DESCRIPTION
In response to https://github.com/dotnet/dotnet-docker/pull/134/files

Tested the debian images this time. Not on a Windows machine right now, so hoping it acts the same.

/cc @MichaelSimons, @kendrahavens