### PR TITLE
Modified update-dependencies to handle PRs from multiple CLI branches

### DIFF
--- a/update-dependencies/Config.cs
+++ b/update-dependencies/Config.cs
@@ -30,6 +30,7 @@ namespace Dotnet.Docker.Nightly
         public string Password => _password.Value;
         public string CliBranch => _cliBranch.Value;
         public string CliVersionUrl => $"https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/cli/{CliBranch}";
+        public string BranchTagPrefix => CliBranch.Replace('/', '-');
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
         public string GitHubProject => _gitHubProject.Value;
         public string GitHubUpstreamBranch => _gitHubUpstreamBranch.Value;


### PR DESCRIPTION
Currently the update-dependencies implementation only handles changes from a single CLI branch correctly.  If Maestro is hooked up to multiple branches and builds happen for those branches concurrently, update-dependencies will create a single PR to update the Dockerfiles corresponding to the multiple branches.  This is not the desired behavior, we need the ability to merge in changes from branches independently.  For example, right now we don't want to merge in changes from rel/1.0.0 because it is in a bad state but we want the changes coming from rel/1.0.0-preview2.1. 

@naamunds, @dagood 