### PR TITLE
Updated 1.0 Dockerfiles to use 1.0.1

### DIFF
--- a/1.0/debian/runtime-deps/hooks/post_push
+++ b/1.0/debian/runtime-deps/hooks/post_push
@@ -15,12 +15,12 @@ echo "Pushing runtime-deps images"
 tagStartIndex=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStartIndex - 1}
 
-imageName=$repoName":1.0.2-runtime-deps"
+imageName=$repoName":1.0.1-runtime-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
 echo "Pushing runtime images"
-imageName=$repoName":1.0.2-runtime"
+imageName=$repoName":1.0.1-runtime"
 docker tag runtime $imageName
 docker push $imageName
 

--- a/1.0/debian/runtime/Dockerfile
+++ b/1.0/debian/runtime/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.2
+ENV DOTNET_VERSION 1.0.1
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/debian/sdk/msbuild/Dockerfile
+++ b/1.0/debian/sdk/msbuild/Dockerfile
@@ -16,23 +16,15 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.2
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
-
-RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview3-003933
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/1.0/debian/sdk/projectjson/Dockerfile
+++ b/1.0/debian/sdk/projectjson/Dockerfile
@@ -16,23 +16,15 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.2
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
-
-RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/1.0/nanoserver/runtime/Dockerfile
+++ b/1.0/nanoserver/runtime/Dockerfile
@@ -1,7 +1,7 @@
 FROM microsoft/nanoserver:10.0.14393.321
 
 # Install .NET Core
-ENV DOTNET_VERSION 1.0.2
+ENV DOTNET_VERSION 1.0.1
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
 RUN powershell -NoProfile -Command \

--- a/1.0/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.0/nanoserver/sdk/msbuild/Dockerfile
@@ -1,17 +1,5 @@
 FROM microsoft/nanoserver:10.0.14393.321
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.2
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
-
-RUN powershell -NoProfile -Command \
-        $ErrorActionPreference = 'Stop'; \
-        Invoke-WebRequest %DOTNET_DOWNLOAD_URL% -OutFile dotnet.zip; \
-        Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet'; \
-        Remove-Item -Force dotnet.zip
-
-RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview3-003830
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
@@ -21,6 +9,8 @@ RUN powershell -NoProfile -Command \
         Invoke-WebRequest %DOTNET_SDK_DOWNLOAD_URL% -OutFile dotnet.zip; \
         Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet' -Force; \
         Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/1.0/nanoserver/sdk/projectjson/Dockerfile
+++ b/1.0/nanoserver/sdk/projectjson/Dockerfile
@@ -1,17 +1,5 @@
 FROM microsoft/nanoserver:10.0.14393.321
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.2
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
-
-RUN powershell -NoProfile -Command \
-        $ErrorActionPreference = 'Stop'; \
-        Invoke-WebRequest %DOTNET_DOWNLOAD_URL% -OutFile dotnet.zip; \
-        Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet'; \
-        Remove-Item -Force dotnet.zip
-
-RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview2-003131
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
@@ -21,6 +9,8 @@ RUN powershell -NoProfile -Command \
         Invoke-WebRequest %DOTNET_SDK_DOWNLOAD_URL% -OutFile dotnet.zip; \
         Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet' -Force; \
         Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/1.1/README.md
+++ b/1.1/README.md
@@ -15,16 +15,16 @@ You can find samples, documentation, and getting started instructions for .NET C
 
 ## Supported tags
 
--       ['1.0.2-runtime', '1.0-runtime' (*1.0/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/runtime/Dockerfile)
--       ['1.0.2-runtime-nanoserver', '1.0-runtime-nanoserver' (*1.0/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/runtime/Dockerfile)
--       ['1.0.2-runtime-deps', '1.0-runtime-deps' (*1.0/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/runtime-deps/Dockerfile)
+-       ['1.0.1-runtime', '1.0-runtime' (*1.0/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/runtime/Dockerfile)
+-       ['1.0.1-runtime-nanoserver', '1.0-runtime-nanoserver' (*1.0/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/runtime/Dockerfile)
+-       ['1.0.1-runtime-deps', '1.0-runtime-deps' (*1.0/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/runtime-deps/Dockerfile)
 -       ['1.1.0-runtime', '1.1-runtime', '1-runtime', 'runtime' (*1.1/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime/Dockerfile)
 -       ['1.1.0-runtime-nanoserver', '1.1-runtime-nanoserver', '1-runtime-nanoserver', 'runtime-nanoserver' (*1.1/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/runtime/Dockerfile)
 -       ['1.1.0-runtime-deps', '1.1-runtime-deps', '1-runtime-deps', 'runtime-deps' (*1.1/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime-deps/Dockerfile)
--       ['1.0.2-sdk-projectjson', '1.0-sdk-projectjson', 'latest' (*1.0/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/sdk/projectjson/Dockerfile)
--       ['1.0.2-sdk-projectjson-nanoserver', '1.0-sdk-projectjson' (*1.0/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/sdk/projectjson/Dockerfile)
--       ['1.0.2-sdk-msbuild', '1.0-sdk' (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
--       ['1.0.2-sdk-msbuild-nanoserver', '1.0-sdk-nanoserver' (*1.0/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/sdk/msbuild/Dockerfile)
+-       ['1.0.1-sdk-projectjson', '1.0-sdk-projectjson', 'latest' (*1.0/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/sdk/projectjson/Dockerfile)
+-       ['1.0.1-sdk-projectjson-nanoserver', '1.0-sdk-projectjson' (*1.0/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/sdk/projectjson/Dockerfile)
+-       ['1.0.1-sdk-msbuild', '1.0-sdk' (*1.0/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/debian/sdk/msbuild/Dockerfile)
+-       ['1.0.1-sdk-msbuild-nanoserver', '1.0-sdk-nanoserver' (*1.0/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/nanoserver/sdk/msbuild/Dockerfile)
 -       ['1.1.0-sdk-projectjson', '1.1-sdk-projectjson' (*1.1/debian/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/projectjson/Dockerfile)
 -       ['1.1.0-sdk-projectjson-nanoserver', '1.1-sdk-projectjson-nanoserver' (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
 -       ['1.1.0-sdk-msbuild', '1.1-sdk' (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/msbuild/Dockerfile)

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -13,18 +13,11 @@ if (-NOT $?) {
     throw  "Failed to create project"
 }
 
-cp c:\test\NuGet.Config .
+if ($SdkTag.StartsWith("1.1")) {
+    (Get-Content project.json).replace("1.0.1", "1.1.0") | Set-Content project.json
 
-$cliVersion="1.0.1"
-
-if ($SdkTag.StartsWith("1.0")) {
-    $runtimeVersion="1.0.2"
+    cp c:\test\NuGet.Config .    
 }
-else {
-    $runtimeVersion="1.1.0"
-}
-
-(Get-Content project.json).replace($cliVersion, $runtimeVersion) | Set-Content project.json
 
 dotnet restore
 if (-NOT $?) {

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -9,20 +9,16 @@ cd $1
 echo "Testing framework-dependent deployment"
 dotnet new
 
-cp /test/NuGet.Config .
+if [[ $2 == "1.1"* ]]; then
+    replacement_arg="s/1.0.1/1.1.0/"
 
-cli_version="1.0.1"
+    if [[ $2 == *"projectjson"* ]]; then
+        sed -i ${replacement_arg} ./project.json
+    else
+        sed -i ${replacement_arg} ./${PWD##*/}.csproj
+    fi
 
-if [[ $2 == "1.0"* ]]; then
-    runtime_version="1.0.2"
-else
-    runtime_version="1.1.0"
-fi
-
-if [[ $2 == *"projectjson"* ]]; then
-    sed -i "s/${cli_version}/${runtime_version}/" ./project.json
-else
-    sed -i "s/${cli_version}/${runtime_version}/" ./${PWD##*/}.csproj
+    cp /test/NuGet.Config .    
 fi
 
 dotnet restore


### PR DESCRIPTION
Using 1.0.2 was a mistake.  1.0.2 didn't ship any updates for Debian.  1.0.1 is the current runtime the Dockerfiles should be using.