### PR TITLE
Back porting official changes to nightly

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -209,7 +209,7 @@ It contains the .NET Core SDK which is comprised of two parts:
 
 Use this image for your development process (developing, building and testing applications).
 
-There currently are two flavors of the sdk images, `projectjson` and `msbuild`.  These two flavors exist while the [transition occurs from project.json to msbuild](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/).  Once the tooling is release, there will only be one msbuild based sdk image which will be based on msbuild.
+There currently are two flavors of the sdk images, `projectjson` and `msbuild`.  These two flavors exist while the [transition occurs from project.json to msbuild](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/).  Once the tooling stabilizes the project json variant will be deprecated and there will only be a msbuild variant.
 
 ### `microsoft/dotnet-nightly:<version>-runtime`
 

--- a/1.0/README.md
+++ b/1.0/README.md
@@ -209,7 +209,7 @@ It contains the .NET Core SDK which is comprised of two parts:
 
 Use this image for your development process (developing, building and testing applications).
 
-There currently are two flavors of the sdk images, `projectjson` and `msbuild`.  These two flavors exist while the [transition occurs from project.json to msbuild](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/).  Once the tooling stabilizes the project json variant will be deprecated and there will only be a msbuild variant.
+There currently are two flavors of the sdk images, `projectjson` and `msbuild`.  These two flavors exist while the [transition occurs from project.json to msbuild](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/).  Once the tooling stabilizes, the project json variant will be deprecated and there will only be an msbuild variant.
 
 ### `microsoft/dotnet-nightly:<version>-runtime`
 

--- a/1.0/debian/runtime-deps/hooks/post_push
+++ b/1.0/debian/runtime-deps/hooks/post_push
@@ -19,11 +19,30 @@ imageName=$repoName":1.0.1-runtime-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
+# Existing core-deps tags are obsolete but being preserved for through the 1* release
+imageName=$repoName":1.0.1-core-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+imageName=$repoName":1.0-core-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+
 echo "Pushing runtime images"
 imageName=$repoName":1.0.1-runtime"
 docker tag runtime $imageName
 docker push $imageName
 
 imageName=$repoName":1.0-runtime"
+docker tag runtime $imageName
+docker push $imageName
+
+# Existing core tags are obsolete but being preserved for through the 1* release
+imageName=$repoName":1.0.1-core"
+docker tag runtime $imageName
+docker push $imageName
+
+imageName=$repoName":1.0-core"
 docker tag runtime $imageName
 docker push $imageName

--- a/1.1/debian/runtime-deps/hooks/post_push
+++ b/1.1/debian/runtime-deps/hooks/post_push
@@ -27,6 +27,15 @@ imageName=$repoName":runtime-deps"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
+# Existing core-deps tags are obsolete but being preserved for through the 1* release
+imageName=$repoName":1-core-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+latestImageName=$repoName":core-deps"
+docker tag $IMAGE_NAME $latestImageName
+docker push $latestImageName
+
 
 echo "Pushing runtime images"
 imageName=$repoName":1.1.0-runtime"
@@ -44,3 +53,12 @@ docker push $imageName
 imageName=$repoName":runtime"
 docker tag runtime $imageName
 docker push $imageName
+
+# Existing core tags are obsolete but being preserved for through the 1* release
+imageName=$repoName":1-core"
+docker tag runtime $imageName
+docker push $imageName
+
+latestImageName=$repoName":core"
+docker tag runtime $latestImageName
+docker push $latestImageName

--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -41,9 +41,8 @@ RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
     # Projects created with .NET Core SDK preview3 target 1.0, replace with 1.1 to populate cache
-    && sed -i "s/1.0.1/1.1.0/" ./warmup.csproj \
-    # Need to use myget cache because 1.1 hasn't released
-    && dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json \
+    && sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./warmup.csproj \
+    && dotnet restore \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -29,8 +29,7 @@ RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
     # .NET Core SDK preview3 targets 1.0, replace with 1.1 to populate cache
-    && powershell -NoProfile -Command "(Get-Content project.json).replace('1.0.1', '1.1.0') | Set-Content project.json" \
-    # Need to use myget cache because 1.1 hasn't released
-    && dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json \
+    && powershell -NoProfile -Command "(Get-Content project.json).replace('1.0.1', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content project.json" \
+    && dotnet restore \
     && cd .. \
     && rmdir /q/s warmup

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -13,8 +13,8 @@ if (-NOT $?) {
     throw  "Failed to create project"
 }
 
-if ($SdkTag.StartsWith("1.1")) {
-    (Get-Content project.json).replace("1.0.1", "1.1.0") | Set-Content project.json
+if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
+    (Get-Content project.json).replace("1.0.1", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content project.json
 }
 
 dotnet restore

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -9,14 +9,8 @@ cd $1
 echo "Testing framework-dependent deployment"
 dotnet new
 
-if [[ $2 == "1.1"* ]]; then
-    replacement_arg="s/1.0.1/1.1.0/"
-
-    if [[ $2 == *"projectjson"* ]]; then
-        sed -i ${replacement_arg} ./project.json
-    else
-        sed -i ${replacement_arg} ./${PWD##*/}.csproj
-    fi
+if [[ $2 == "1.1-sdk-msbuild" ]]; then
+    sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
 fi
 
 dotnet restore
@@ -30,14 +24,12 @@ if [[ $2 == *"projectjson"* ]]; then
     sed -i '/"type": "platform"/d' ./project.json
     sed -i "s/^  }$/${runtimes_section}/" ./project.json
 
-    # Need to use myget cache because 1.1 hasn't released.
-    dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+    dotnet restore
     dotnet run
     dotnet publish -o publish/self-contained
 else
     sed -i '/<PropertyGroup>/a \    <RuntimeIdentifiers>debian.8-x64<\/RuntimeIdentifiers>' ./${PWD##*/}.csproj
 
-    # Need to use myget cache because 1.1 hasn't released.
-    dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+    dotnet restore
     dotnet publish -r debian.8-x64 -o publish/self-contained
 fi


### PR DESCRIPTION
These changes include the build hooks to create the deprecated "core" tags.  This is done to make the release process easier in that nightly is truly a staging environment for official.   

@naamunds 