### PR TITLE
Modified update-dependencies logic to handle distinguishing preview2 from preview2-1

### DIFF
--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -108,7 +108,7 @@ namespace Dotnet.Docker.Nightly
             {
                 Path = path,
                 BuildInfoName = "Cli",
-                Regex = new Regex($@"ENV DOTNET_SDK_VERSION [\d\.]*-(?<version>{s_config.CliReleaseMoniker}-[\d]*)\r\n"),
+                Regex = new Regex($@"ENV DOTNET_SDK_VERSION [\d\.]*-(?<version>{s_config.CliReleaseMoniker}-\d+)\r\n"),
                 VersionGroupName = "version"
             };
         }

--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -108,7 +108,7 @@ namespace Dotnet.Docker.Nightly
             {
                 Path = path,
                 BuildInfoName = "Cli",
-                Regex = new Regex($@"ENV DOTNET_SDK_VERSION [\d\.]*-(?<version>{s_config.CliReleaseMoniker}-[^\r\n]*)"),
+                Regex = new Regex($@"ENV DOTNET_SDK_VERSION [\d\.]*-(?<version>{s_config.CliReleaseMoniker}-[\d]*)\r\n"),
                 VersionGroupName = "version"
             };
         }


### PR DESCRIPTION
I discovered this issue while adding a Maestro hook to update preview2.  It was also replacing the preview2-1 version which is incorrect.

@dotnet-bot skip CI please

@naamunds 