### PR TITLE
Modified build-and-test.ps1 to be xplat

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -3,7 +3,7 @@ param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("win", "linux")]
     [string]$Platform,
-    [switch]$UseImageCache=$false
+    [switch]$UseImageCache
 )
 
 Set-StrictMode -Version Latest

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -1,19 +1,57 @@
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("win", "linux")]
+    [string]$Platform,
+    [switch]$UseImageCache=$false
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 
 $dockerRepo="microsoft/dotnet-nightly"
+$dirSeparator = [IO.Path]::DirectorySeparatorChar
+
+if ($UseImageCache) {
+    $optionalDockerBuildArgs=""
+}
+else {
+    $optionalDockerBuildArgs = "--no-cache"
+}
+
+if ($Platform -eq "win") {
+    $imageOs = "nanoserver"
+    $tagSuffix = "-nanoserver"
+}
+else {
+    $imageOs = "debian"
+    $tagSuffix = ""
+}
 
 pushd $PSScriptRoot
 
-Get-ChildItem -Recurse -Filter Dockerfile | where {$_.DirectoryName.TrimStart($PSScriptRoot) -like "*\nanoserver*"} | sort DirectoryName | foreach {
-    $tag = "$($dockerRepo):" + $_.DirectoryName.Replace($PSScriptRoot, '').Replace("\nanoserver", '').TrimStart('\').Replace('\', '-') + "-nanoserver"
-    Write-Host "--- Building $tag from $($_.DirectoryName) ---"
-    docker build --no-cache -t $tag $_.DirectoryName
-    if (-NOT $?) {
-        throw "Failed building $tag"
+$tags = [System.Collections.ArrayList]@()
+Get-ChildItem -Recurse -Filter Dockerfile |
+    where {$_.DirectoryName.TrimStart($PSScriptRoot) -like "*$dirSeparator$imageOs*"} |
+    # sort in descending order to ensure runtime-deps get built before runtime to satisfy dependency
+    Sort-Object {$_.DirectoryName} -Descending |
+    foreach {
+        $tag = "${dockerRepo}:" +
+            $_.DirectoryName.
+                Replace("$PSScriptRoot$dirSeparator", '').
+                Replace("$dirSeparator$imageOs", '').
+                Replace($dirSeparator, '-') +
+            $tagSuffix
+        $tags.Add($tag) | Out-Null
+        Write-Host "--- Building $tag from $($_.DirectoryName) ---"
+        docker build $optionalDockerBuildArgs -t $tag $_.DirectoryName
+        if (-NOT $?) {
+            throw "Failed building $tag"
+        }
     }
-}
-
-./test/run-test.ps1
 
 popd
+
+./test/run-test.ps1 -Platform $Platform
+
+Write-Host "Tags built and tested:`n$($tags | Out-String)"

--- a/netci.groovy
+++ b/netci.groovy
@@ -13,7 +13,7 @@ platformList.each { platform ->
     def newJob = job(newJobName) {
         steps {
             if (hostOS == 'Windows_2016') {
-                batchFile("powershell -NoProfile -Command .\\build-and-test.ps1")
+                batchFile("powershell -NoProfile -Command .\\build-and-test.ps1 -Platform win")
             }
             else {
                 shell("./build-and-test.sh")

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -30,7 +30,7 @@ if (-NOT $?) {
     throw  "Failed to run app"
 }
 
-dotnet publish -o publish
+dotnet publish -o publish/framework-dependent
 if (-NOT $?) {
     throw  "Failed to publish app"
 }

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -1,42 +1,89 @@
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("win", "linux")]
+    [string]$Platform
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 
 $dockerRepo="microsoft/dotnet-nightly"
+$dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
-if ($env:DEBUGTEST -eq $null) {
-    $optionalDockerRunArgs="--rm"
+if ($Platform -eq "win") {
+    $imageOs = "nanoserver"
+    $tagSuffix = "-nanoserver"
+    $testScriptSuffix = "ps1"
+    $containerRoot = "C:\"
+    $sdkRunArg = "powershell"
 }
 else {
-    $optionalDockerRunArgs=""
+    $imageOs = "debian"
+    $tagSuffix = ""
+    $testScriptSuffix = "sh"
+    $containerRoot = "/"
+    $sdkRunArg = ""
 }
 
 pushd $repoRoot
 
 # Loop through each sdk Dockerfile in the repo and test the sdk and runtime images.
-Get-ChildItem -Recurse -Filter Dockerfile | where DirectoryName -like "*\nanoserver\sdk\*" | foreach {
-    $sdkTag = $_.DirectoryName.Replace($repoRoot, '').Replace("\nanoserver", '').TrimStart('\').Replace('\', '-') + "-nanoserver"
+Get-ChildItem -Recurse -Filter Dockerfile |
+    where DirectoryName -like "*${dirSeparator}${imageOs}${dirSeparator}sdk${dirSeparator}*" |
+    foreach {
+        $sdkTag = $_.DirectoryName.
+                Replace("$repoRoot$dirSeparator", '').
+                Replace("$dirSeparator$imageOs", '').
+                Replace($dirSeparator, '-') +
+            $tagSuffix
 
-    $fullSdkTag="$($dockerRepo):$sdkTag"
-    $baseTag="$fullSdkTag".Replace("-sdk", '').Replace("-msbuild", '').Replace("-projectjson", '').Replace("-nanoserver", '')
+        $fullSdkTag="${dockerRepo}:${sdkTag}"
+        $baseTag=$fullSdkTag.
+            TrimEnd($tagSuffix).
+            TrimEnd("-msbuild").
+            TrimEnd("-projectjson").
+            TrimEnd("-sdk")
 
-    $timeStamp = Get-Date -Format FileDateTime
-    $appName="app$timeStamp"
-    $appDir="${repoRoot}\.test-assets\${appName}"
+        $timeStamp = Get-Date -Format FileDateTime
+        $appName="app$timeStamp"
+        $appDir="$repoRoot$dirSeparator.test-assets$dirSeparator$appName"
 
-    New-Item $appDir -type directory | Out-Null
+        New-Item $appDir -type directory | Out-Null
 
-    Write-Host "----- Testing $fullSdkTag -----"
-    docker run -t $optionalDockerRunArgs -v "$($appDir):c:\$appName" -v "$repoRoot\test:c:\test" --name "sdk-test-$appName" --entrypoint powershell "$fullSdkTag" c:\test\create-run-publish-app.ps1 "c:\$appName" "${sdkTag}"
-    if (-NOT $?) {
-        throw  "Testing $full_sdk_tag failed"
+        Write-Host "----- Testing $fullSdkTag -----"
+        docker run -it --rm `
+            -v "${appDir}:${containerRoot}${appName}" `
+            -v "${repoRoot}${dirSeparator}test:${containerRoot}test" `
+            --name "sdk-test-$appName" `
+            $fullSdkTag $sdkRunArg "${containerRoot}test${dirSeparator}create-run-publish-app.${testScriptSuffix}" "${containerRoot}${appName}" $sdkTag
+        if (-NOT $?) {
+            throw  "Testing $fullSdkTag failed"
+        }
+
+        Write-Host "----- Testing $baseTag-runtime$tagSuffix with $sdkTag app -----"
+        docker run -t --rm `
+            -v "${appDir}:${containerRoot}${appName}" `
+            --name "runtime-test-$appName" `
+            --entrypoint dotnet `
+            "$baseTag-runtime$tagSuffix" `
+            "${containerRoot}${appName}${dirSeparator}publish${dirSeparator}framework-dependent${dirSeparator}${appName}.dll"
+        if (-NOT $?) {
+            throw  "Testing $baseTag-runtime failed"
+        }
+
+        if ($Platform -eq "linux") {
+            Write-Host "----- Testing $baseTag-runtime-deps with $sdkTag app -----"
+            docker run -t --rm `
+                -v "${appDir}:${containerRoot}${appName}" `
+                --name "runtime-deps-test-$appName" `
+                --entrypoint "${containerRoot}${appName}${dirSeparator}publish${dirSeparator}self-contained${dirSeparator}${appName}" `
+                "$baseTag-runtime-deps"
+            if (-NOT $?) {
+                throw  "Testing $baseTag-runtime-deps failed"
+            }
+        }
     }
-
-    Write-Host "----- Testing $baseTag-runtime-nanoserver -----"
-    docker run -t $optionalDockerRunArgs -v "$($appDir):c:\$appName" --name "runtime-test-$appName" --entrypoint dotnet "$baseTag-runtime-nanoserver" "C:\$appName\publish\$appName.dll"
-    if (-NOT $?) {
-        throw  "Testing $baseTag-runtime failed"
-    }
-}
 
 popd

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -53,7 +53,7 @@ Get-ChildItem -Recurse -Filter Dockerfile |
         New-Item $appDir -type directory | Out-Null
 
         Write-Host "----- Testing $fullSdkTag -----"
-        docker run -it --rm `
+        docker run -t --rm `
             -v "${appDir}:${containerRoot}${appName}" `
             -v "${repoRoot}${dirSeparator}test:${containerRoot}test" `
             --name "sdk-test-$appName" `
@@ -70,18 +70,18 @@ Get-ChildItem -Recurse -Filter Dockerfile |
             "$baseTag-runtime$tagSuffix" `
             "${containerRoot}${appName}${dirSeparator}publish${dirSeparator}framework-dependent${dirSeparator}${appName}.dll"
         if (-NOT $?) {
-            throw  "Testing $baseTag-runtime failed"
+            throw  "Testing $baseTag-runtime$tagSuffix failed"
         }
 
         if ($Platform -eq "linux") {
-            Write-Host "----- Testing $baseTag-runtime-deps with $sdkTag app -----"
+            Write-Host "----- Testing $baseTag-runtime-deps$tagSuffix with $sdkTag app -----"
             docker run -t --rm `
                 -v "${appDir}:${containerRoot}${appName}" `
                 --name "runtime-deps-test-$appName" `
                 --entrypoint "${containerRoot}${appName}${dirSeparator}publish${dirSeparator}self-contained${dirSeparator}${appName}" `
-                "$baseTag-runtime-deps"
+                "$baseTag-runtime-deps$tagSuffix"
             if (-NOT $?) {
-                throw  "Testing $baseTag-runtime-deps failed"
+                throw  "Testing $baseTag-runtime-deps$tagSuffix failed"
             }
         }
     }


### PR DESCRIPTION
This is the first iteration towards having one set of CI scripts for all supported platforms.  The next step would be to get Jenkins to install Powershell and utilize these changes.  Once this is done the bash scripts can be removed and we then only have one set of scripts to maintain.

@naamunds 