### PR TITLE
Upgrading to CLI 1.0.0-preview5-004432

### DIFF
--- a/1.0/debian/sdk/msbuild/Dockerfile
+++ b/1.0/debian/sdk/msbuild/Dockerfile
@@ -16,33 +16,21 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.3
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 1.0.0-preview5-004432
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
-RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
-# Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview5-004232
-ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
-
-RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz
-
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
-    # Projects created with .NET Core SDK preview5 target 1.0.1, replace with 1.0.3 to populate cache
-    && sed -i "s/1.0.1/1.0.3/" ./warmup.csproj \
-    && dotnet restore \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch

--- a/1.0/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.0/nanoserver/sdk/msbuild/Dockerfile
@@ -1,19 +1,7 @@
 FROM microsoft/nanoserver:10.0.14393.576
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.0.3
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
-
-RUN powershell -NoProfile -Command \
-        $ErrorActionPreference = 'Stop'; \
-        Invoke-WebRequest %DOTNET_DOWNLOAD_URL% -OutFile dotnet.zip; \
-        Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet'; \
-        Remove-Item -Force dotnet.zip
-
-RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview3-003830
+ENV DOTNET_SDK_VERSION 1.0.0-preview5-004432
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN powershell -NoProfile -Command \
@@ -22,14 +10,12 @@ RUN powershell -NoProfile -Command \
         Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet' -Force; \
         Remove-Item -Force dotnet.zip
 
+RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
+
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
-    # Projects created with .NET Core SDK preview3 target 1.0.1, replace with 1.0.3 to populate cache
-    && powershell -NoProfile -Command "(Get-Content project.json).replace('1.0.1', '1.0.3') | Set-Content project.json" \
-    && dotnet restore \
     && cd .. \
     && rmdir /q/s warmup

--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview5-004232
+ENV DOTNET_SDK_VERSION 1.0.0-preview5-004432
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
     # Projects created with .NET Core SDK preview5 target 1.0, replace with 1.1 to populate cache
-    && sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./warmup.csproj \
+    && sed -i "s/1.0.3/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./warmup.csproj \
     && dotnet restore \
     && cd .. \
     && rm -rf warmup \

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
     # Projects created with .NET Core SDK preview5 target 1.0, replace with 1.1 to populate cache
-    && powershell -NoProfile -Command "(Get-Content warmup.csproj).replace('1.0.1', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content warmup.csproj" \
+    && powershell -NoProfile -Command "(Get-Content warmup.csproj).replace('1.0.3', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content warmup.csproj" \
     && dotnet restore \
     && cd .. \
     && rmdir /q/s warmup

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -13,7 +13,7 @@ RUN powershell -NoProfile -Command \
 RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-preview3-003830
+ENV DOTNET_SDK_VERSION 1.0.0-preview5-004432
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN powershell -NoProfile -Command \
@@ -28,8 +28,8 @@ ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
-    # .NET Core SDK preview3 targets 1.0, replace with 1.1 to populate cache
-    && powershell -NoProfile -Command "(Get-Content project.json).replace('1.0.1', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content project.json" \
+    # Projects created with .NET Core SDK preview5 target 1.0, replace with 1.1 to populate cache
+    && powershell -NoProfile -Command "(Get-Content warmup.csproj).replace('1.0.1', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content warmup.csproj" \
     && dotnet restore \
     && cd .. \
     && rmdir /q/s warmup

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -5,7 +5,7 @@ param(
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference="Stop"
+$ErrorActionPreference = "Stop"
 
 cd $AppDirectory
 dotnet new
@@ -13,11 +13,9 @@ if (-NOT $?) {
     throw  "Failed to create project"
 }
 
-if ($SdkTag -eq "1.0-sdk-msbuild-nanoserver") {
-    (Get-Content project.json).replace("1.0.1", "1.0.3") | Set-Content project.json
-}
-elseif ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
-    (Get-Content project.json).replace("1.0.1", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content project.json
+if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
+    $projectName = "$($pwd.path | Split-Path -Leaf).csproj"
+    (Get-Content $projectName).replace("1.0.1", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content $projectName
 }
 
 dotnet restore

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -15,7 +15,7 @@ if (-NOT $?) {
 
 if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
     $projectName = "$($pwd.path | Split-Path -Leaf).csproj"
-    (Get-Content $projectName).replace("1.0.1", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content $projectName
+    (Get-Content $projectName).replace("1.0.3", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content $projectName
 }
 
 dotnet restore

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -10,7 +10,7 @@ echo "Testing framework-dependent deployment"
 dotnet new
 
 if [[ $2 == "1.1-sdk-msbuild" ]]; then
-    sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
+    sed -i "s/1.0.3/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
 fi
 
 dotnet restore

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -9,9 +9,7 @@ cd $1
 echo "Testing framework-dependent deployment"
 dotnet new
 
-if [[ $2 == "1.0-sdk-msbuild" ]]; then
-    sed -i "s/1.0.1/1.0.3/" ./${PWD##*/}.csproj
-elif [[ $2 == "1.1-sdk-msbuild" ]]; then
+if [[ $2 == "1.1-sdk-msbuild" ]]; then
     sed -i "s/1.0.1/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
 fi
 


### PR DESCRIPTION
CLI is now based on 1.0.3 therefore we no longer need to explicitly install the 1.0.3 runtime for the 1.0 images.  Additionally the latest CLI now supports Nano Server again therefore the nano images were updated to use the latest preview5 CLI.