### PR TITLE
Removed explicit install of 1.1 runtime in 1.1-sdk-msbuild Dockerfiles

### DIFF
--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -16,23 +16,15 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.1.0
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
-
-RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview5-004475
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -1,17 +1,5 @@
 FROM microsoft/nanoserver:10.0.14393.693
 
-# Install .NET Core
-ENV DOTNET_VERSION 1.1.0
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
-
-RUN powershell -NoProfile -Command \
-        $ErrorActionPreference = 'Stop'; \
-        Invoke-WebRequest %DOTNET_DOWNLOAD_URL% -OutFile dotnet.zip; \
-        Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet'; \
-        Remove-Item -Force dotnet.zip
-
-RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
-
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 1.0.0-preview5-004475
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
@@ -21,6 +9,8 @@ RUN powershell -NoProfile -Command \
         Invoke-WebRequest %DOTNET_SDK_DOWNLOAD_URL% -OutFile dotnet.zip; \
         Expand-Archive dotnet.zip -DestinationPath '%ProgramFiles%\dotnet' -Force; \
         Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip


### PR DESCRIPTION
This is no longer necessary because of https://github.com/dotnet/cli/pull/5225