### PR TITLE
Utilize dotnet package warmup logic for rc3

### DIFF
--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -28,13 +28,9 @@ RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
-    # Projects created with .NET Core SDK rc3 target 1.0, replace with 1.1 to populate cache
-    && sed -i "s/1.0.3/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./warmup.csproj \
-    && dotnet restore \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -14,12 +14,8 @@ RUN setx /M PATH "%PATH%;%ProgramFiles%\dotnet"
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE true
 RUN mkdir warmup \
     && cd warmup \
     && dotnet new \
-    # Projects created with .NET Core SDK rc3 target 1.0, replace with 1.1 to populate cache
-    && powershell -NoProfile -Command "(Get-Content warmup.csproj).replace('1.0.3', '1.1.0').replace('netcoreapp1.0', 'netcoreapp1.1') | Set-Content warmup.csproj" \
-    && dotnet restore \
     && cd .. \
     && rmdir /q/s warmup

--- a/test/create-run-publish-app.ps1
+++ b/test/create-run-publish-app.ps1
@@ -8,14 +8,15 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 cd $AppDirectory
-dotnet new
-if (-NOT $?) {
-    throw  "Failed to create project"
+if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
+    dotnet new -t Console1.1
+}
+else {
+    dotnet new
 }
 
-if ($SdkTag -eq "1.1-sdk-msbuild-nanoserver") {
-    $projectName = "$($pwd.path | Split-Path -Leaf).csproj"
-    (Get-Content $projectName).replace("1.0.3", "1.1.0").replace("netcoreapp1.0", "netcoreapp1.1") | Set-Content $projectName
+if (-NOT $?) {
+    throw  "Failed to create project"
 }
 
 dotnet restore

--- a/test/create-run-publish-app.sh
+++ b/test/create-run-publish-app.sh
@@ -7,10 +7,10 @@ set -e  # Exit immediately upon failure
 cd $1
 
 echo "Testing framework-dependent deployment"
-dotnet new
-
 if [[ $2 == "1.1-sdk-msbuild" ]]; then
-    sed -i "s/1.0.3/1.1.0/;s/netcoreapp1.0/netcoreapp1.1/" ./${PWD##*/}.csproj
+    dotnet new -t Console1.1
+else
+    dotnet new
 fi
 
 dotnet restore


### PR DESCRIPTION
With the latest changes CLI made to install both the current and LTS runtime, the warmup logic was also modified to initialize the NuGet package cache for both.  Because of this, the logic needed to trigger the cache warmup for current is not needed therefore it was removed.  I also tweaked the test code to make use of the new -t console1.1 logic for simplification.