### PR TITLE
Updating to CLI to 1.0.0-rc4-004756

### DIFF
--- a/1.0/debian/sdk/msbuild/Dockerfile
+++ b/1.0/debian/sdk/msbuild/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004711
+ENV DOTNET_SDK_VERSION 1.0.0-rc4-004756
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.0/nanoserver/sdk/msbuild/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004711
+ENV DOTNET_SDK_VERSION 1.0.0-rc4-004756
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.1/debian/sdk/msbuild/Dockerfile
+++ b/1.1/debian/sdk/msbuild/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004711
+ENV DOTNET_SDK_VERSION 1.0.0-rc4-004756
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/nanoserver/sdk/msbuild/Dockerfile
+++ b/1.1/nanoserver/sdk/msbuild/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004711
+ENV DOTNET_SDK_VERSION 1.0.0-rc4-004756
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -63,7 +63,10 @@ Get-ChildItem -Recurse -Filter Dockerfile |
         $buildImage = "sdk-build-$appName"
         $dotnetNewParam = ""
         if ($sdkTag -like "*1.1-sdk-msbuild*") {
-            $dotnetNewParam = "-t Console1.1"
+            $dotnetNewParam = "console --Framework netcoreapp1.1"
+        }
+        elseif ($sdkTag -like "*1.0-sdk-msbuild*") {
+            $dotnetNewParam = "console --Framework netcoreapp1.0"
         }
         $dockerFilesPath = "${repoRoot}${dirSeparator}test${dirSeparator}"
 


### PR DESCRIPTION
The latest CLI introduced [new `dotnet new` functionality](2d93968a88a724ec69a3c3cfd0ad92576101cbfe) therefore the tests needed to be updated accordingly.