### PR TITLE
Added Dockerfiles for 2.0

### DIFF
--- a/1.0/README.md
+++ b/1.0/README.md
@@ -18,11 +18,11 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 -       [`1.1.0-sdk-projectjson-nanoserver`, `1.1-sdk-projectjson-nanoserver`, `1-sdk-projectjson-nanoserver`, `sdk-nanoserver`, `nanoserver` (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
 -       [`1.1.0-sdk-msbuild-rc4`, `1.1-sdk-msbuild`, `1-sdk-msbuild` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
 -       [`1.1.0-sdk-msbuild-rc4-nanoserver`, `1.1-sdk-msbuild-nanoserver`, `1-sdk-msbuild-nanoserver` (*1.1/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/msbuild/Dockerfile)
--       [`2.0.0-beta-runtime`, `2.0-runtime`, `2-runtime` (*1.1/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime/Dockerfile)
--       [`2.0.0-beta-runtime-nanoserver`, `2.0-runtime-nanoserver`, `2-runtime-nanoserver` (*1.1/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/runtime/Dockerfile)
--       [`2.0.0-beta-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps` (*1.1/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime-deps/Dockerfile)
--       [`2.0.0-beta-sdk`, `2.0-sdk`, `2-sdk` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
--       [`2.0.0-beta-sdk-nanoserver`, `2.0-sdk-nanoserver`, `2-sdk-nanoserver` (*1.1/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/msbuild/Dockerfile)
+-       [`2.0.0-beta-runtime`, `2.0-runtime`, `2-runtime` (*2.0/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/debian/runtime/Dockerfile)
+-       [`2.0.0-beta-runtime-nanoserver`, `2.0-runtime-nanoserver`, `2-runtime-nanoserver` (*2.0/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/nanoserver/runtime/Dockerfile)
+-       [`2.0.0-beta-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps` (*2.0/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/debian/runtime-deps/Dockerfile)
+-       [`2.0.0-beta-sdk`, `2.0-sdk`, `2-sdk` (*2.0/debian/sdk/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/debian/sdk/Dockerfile)
+-       [`2.0.0-beta-sdk-nanoserver`, `2.0-sdk-nanoserver`, `2-sdk-nanoserver` (*2.0/nanoserver/sdk/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/nanoserver/sdk/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker-nightly`)](https://github.com/dotnet/dotnet-docker-nightly/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker-nightly` GitHub repo](https://github.com/dotnet/dotnet-docker-nightly/pulls?utf8=%E2%9C%93&q=).
 

--- a/1.0/README.md
+++ b/1.0/README.md
@@ -18,6 +18,11 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 -       [`1.1.0-sdk-projectjson-nanoserver`, `1.1-sdk-projectjson-nanoserver`, `1-sdk-projectjson-nanoserver`, `sdk-nanoserver`, `nanoserver` (*1.1/nanoserver/sdk/projectjson/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/projectjson/Dockerfile)
 -       [`1.1.0-sdk-msbuild-rc4`, `1.1-sdk-msbuild`, `1-sdk-msbuild` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
 -       [`1.1.0-sdk-msbuild-rc4-nanoserver`, `1.1-sdk-msbuild-nanoserver`, `1-sdk-msbuild-nanoserver` (*1.1/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/msbuild/Dockerfile)
+-       [`2.0.0-beta-runtime`, `2.0-runtime`, `2-runtime` (*1.1/debian/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime/Dockerfile)
+-       [`2.0.0-beta-runtime-nanoserver`, `2.0-runtime-nanoserver`, `2-runtime-nanoserver` (*1.1/nanoserver/runtime/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/runtime/Dockerfile)
+-       [`2.0.0-beta-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps` (*1.1/debian/runtime-deps/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/runtime-deps/Dockerfile)
+-       [`2.0.0-beta-sdk`, `2.0-sdk`, `2-sdk` (*1.1/debian/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/debian/sdk/msbuild/Dockerfile)
+-       [`2.0.0-beta-sdk-nanoserver`, `2.0-sdk-nanoserver`, `2-sdk-nanoserver` (*1.1/nanoserver/sdk/msbuild/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/nanoserver/sdk/msbuild/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker-nightly`)](https://github.com/dotnet/dotnet-docker-nightly/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker-nightly` GitHub repo](https://github.com/dotnet/dotnet-docker-nightly/pulls?utf8=%E2%9C%93&q=).
 

--- a/2.0/debian/runtime-deps/Dockerfile
+++ b/2.0/debian/runtime-deps/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:jessie
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu52 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.0/debian/runtime-deps/hooks/post_build
+++ b/2.0/debian/runtime-deps/hooks/post_build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+echo "Building dependent runtime image"
+docker build --rm --force-rm -t runtime ../runtime/

--- a/2.0/debian/runtime-deps/hooks/post_push
+++ b/2.0/debian/runtime-deps/hooks/post_push
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+echo "Pushing additional runtime-deps tags"
+imageName=$DOCKER_REPO":2.0.0-beta-runtime-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+imageName=$DOCKER_REPO":2-runtime-deps"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+
+echo "Pushing runtime tags"
+imageName=$DOCKER_REPO":2.0.0-beta-runtime"
+docker tag runtime $imageName
+docker push $imageName
+
+imageName=$DOCKER_REPO":2.0-runtime"
+docker tag runtime $imageName
+docker push $imageName
+
+imageName=$DOCKER_REPO":2-runtime"
+docker tag runtime $imageName
+docker push $imageName

--- a/2.0/debian/runtime/Dockerfile
+++ b/2.0/debian/runtime/Dockerfile
@@ -1,0 +1,16 @@
+FROM microsoft/dotnet-nightly:2.0-runtime-deps
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.0.0-beta-001486-00
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
+
+RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.0/debian/sdk/Dockerfile
+++ b/2.0/debian/sdk/Dockerfile
@@ -1,0 +1,36 @@
+FROM buildpack-deps:jessie-scm
+
+# Install .NET CLI dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu52 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.0-alpha-004775
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+    && rm -rf /tmp/NuGetScratch

--- a/2.0/debian/sdk/hooks/post_push
+++ b/2.0/debian/sdk/hooks/post_push
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Pushing additional sdk tags"
+imageName=$DOCKER_REPO":2.0.0-beta-sdk"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName
+
+imageName=$DOCKER_REPO":2-sdk"
+docker tag $IMAGE_NAME $imageName
+docker push $imageName

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -1,0 +1,13 @@
+FROM microsoft/nanoserver:10.0.14393.693
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.0.0-beta-001486-00
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
+
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+    Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/nanoserver:10.0.14393.693
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.0-alpha-004775
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
+
+RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+    Remove-Item -Force dotnet.zip
+
+RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN New-Item -Type Directory warmup; \
+    cd warmup; \
+    dotnet new; \
+    cd ..; \
+    Remove-Item -Force -Recurse warmup


### PR DESCRIPTION
projectjson support was dropped.

@richlander, @kendrahavens - please look over the tagging.

@naamunds - The Dockerfiles are for the most part the identical to the 1.1 Dockerfiles except for the runtime and cli versions, download urls, and the debian runtime Dockerfile's FROM image.