### PR TITLE
Update 2.0 runtime to 2.0.0-beta-001486-00

### DIFF
--- a/2.0/debian/runtime/Dockerfile
+++ b/2.0/debian/runtime/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.0.0-beta-001486-00
+ENV DOTNET_VERSION 2.0.0-beta-001507-00
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \


### PR DESCRIPTION
Latest CLI taken in https://github.com/dotnet/dotnet-docker-nightly/commit/cb5d064bf6476ac8f0ab7c6cb06052a725b910cf depends on a new runtime.  Tests didn't catch this.  They will be updated with another PR.  Fixing mismatched runtime image right away.