### PR TITLE
Update 2.0 SDK to alpha-004847

### DIFF
--- a/2.0/debian/sdk/Dockerfile
+++ b/2.0/debian/sdk/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.0.0-alpha-004790
+ENV DOTNET_SDK_VERSION 2.0.0-alpha-004847
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.0.0-alpha-004790
+ENV DOTNET_SDK_VERSION 2.0.0-alpha-004847
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -87,7 +87,7 @@ Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
         if ($platform -eq "linux") {
             $selfContainedImage = "self-contained-build-${buildImage}"
             Write-Host "----- Creating publish-image for self-contained app built on $fullSdkTag -----"
-            exec {(Get-Content ${testFilesPath}Dockerfile.linux.publish).Replace("{image}", $buildImage) `
+            exec { (Get-Content ${testFilesPath}Dockerfile.linux.publish).Replace("{image}", $buildImage) `
                 | docker build $optionalDockerBuildArgs -t $selfContainedImage -
             }
 


### PR DESCRIPTION
This version of CLI contains the new3 functionality.  Because of that the run-test script needed to be updated to invoke `dotnet new` with the appropriate parameters.  This allowed for some logic cleanup.  I also made some other minor cleanup changes.