### PR TITLE
Update 1.0.4 and 1.1.1 SDK Dockerfiles to CLI 1.0.1

### DIFF
--- a/1.0/debian/sdk/Dockerfile
+++ b/1.0/debian/sdk/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004911
+ENV DOTNET_SDK_VERSION 1.0.1-rc4-004939
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.0/debian/sdk/hooks/post_push
+++ b/1.0/debian/sdk/hooks/post_push
@@ -7,6 +7,6 @@ imageName=$DOCKER_REPO":1.0.4-sdk"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
-imageName=$DOCKER_REPO":1.0.4-sdk-1.0.0"
+imageName=$DOCKER_REPO":1.0.4-sdk-1.0.1"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName

--- a/1.0/nanoserver/sdk/Dockerfile
+++ b/1.0/nanoserver/sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004911
+ENV DOTNET_SDK_VERSION 1.0.1-rc4-004939
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \

--- a/1.1/debian/sdk/Dockerfile
+++ b/1.1/debian/sdk/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004911
+ENV DOTNET_SDK_VERSION 1.0.1-rc4-004939
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \

--- a/1.1/debian/sdk/hooks/post_push
+++ b/1.1/debian/sdk/hooks/post_push
@@ -7,7 +7,7 @@ imageName=$DOCKER_REPO":1.1.1-sdk"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 
-imageName=$DOCKER_REPO":1.1.1-sdk-1.0.0"
+imageName=$DOCKER_REPO":1.1.1-sdk-1.0.1"
 docker tag $IMAGE_NAME $imageName
 docker push $imageName
 

--- a/1.1/nanoserver/sdk/Dockerfile
+++ b/1.1/nanoserver/sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.693
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 1.0.0-rc4-004911
+ENV DOTNET_SDK_VERSION 1.0.1-rc4-004939
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \


### PR DESCRIPTION
CLI 1.0.0 based images will continue to be produced but out of the SDK-1.0.0 branch.