### PR TITLE
Changed update-dependencies to support matching on cli version prefix

### DIFF
--- a/update-dependencies/Config.cs
+++ b/update-dependencies/Config.cs
@@ -14,7 +14,8 @@ namespace Dotnet.Docker.Nightly
         private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
 
         private Lazy<string> _cliBranch = new Lazy<string>(() => GetEnvironmentVariable("CLI_BRANCH"));
-        private Lazy<string> _cliReleaseMoniker = new Lazy<string>(() => GetEnvironmentVariable("CLI_RELEASE_MONIKER"));
+        private Lazy<string> _cliReleaseMoniker = new Lazy<string>(() => GetEnvironmentVariable("CLI_RELEASE_MONIKER", ""));
+        private Lazy<string> _cliReleasePrefix = new Lazy<string>(() => GetEnvironmentVariable("CLI_RELEASE_PREFIX"));
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "dotnet-docker-nightly"));
         private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "master"));
@@ -31,6 +32,7 @@ namespace Dotnet.Docker.Nightly
         public string Password => _password.Value;
         public string CliBranch => _cliBranch.Value;
         public string CliReleaseMoniker => _cliReleaseMoniker.Value;
+        public string CliReleasePrefix => _cliReleasePrefix.Value;
         public string CliVersionUrl => $"https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/cli/{CliBranch}";
         public string BranchTagPrefix => CliBranch.Replace('/', '-');
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;

--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -104,11 +104,21 @@ namespace Dotnet.Docker.Nightly
 
         private static IDependencyUpdater CreateDependencyUpdater(string path)
         {
+            string versionRegex;
+            if (string.IsNullOrEmpty(s_config.CliReleaseMoniker))
+            {
+                versionRegex = $@"{s_config.CliReleasePrefix}-(?<version>[^\r\n]*)";
+            }
+            else
+            {
+                versionRegex = $@"[\d\.]*-(?<version>{s_config.CliReleaseMoniker}-\d+)\r\n";
+            }
+
             return new FileRegexReleaseUpdater()
             {
                 Path = path,
                 BuildInfoName = "Cli",
-                Regex = new Regex($@"ENV DOTNET_SDK_VERSION [\d\.]*-(?<version>{s_config.CliReleaseMoniker}-\d+)\r\n"),
+                Regex = new Regex($"ENV DOTNET_SDK_VERSION {versionRegex}"),
                 VersionGroupName = "version"
             };
         }


### PR DESCRIPTION
For the cli 2.0 release there is only one moniker therefore we don't need to match on it.  Since it has been changing from time to time, this change will not require us to update the Maestro subscription as often.

cc @dagood