### PR TITLE
Refactor update-dependencies to update the runtime Dockerfiles

### DIFF
--- a/update-dependencies/CliDependencyHelper.cs
+++ b/update-dependencies/CliDependencyHelper.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Dotnet.Docker.Nightly
+{
+    public static class CliDependencyHelper
+    {
+        private static readonly Lazy<HttpClient> DownloadClient = new Lazy<HttpClient>();
+
+        public static string GetSharedFrameworkVersion(string cliVersion)
+        {
+            Trace.TraceInformation($"Looking for the Shared Framework CLI '{cliVersion}' depends on.");
+
+            string cliCommitHash = GetCommitHash(cliVersion);
+            XDocument depVersions = DownloadDependencyVersions(cliCommitHash).Result;
+            XNamespace msbuildNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+            string sharedFrameworkVersion = depVersions.Document.Root
+                .Element(msbuildNamespace + "PropertyGroup")
+                ?.Element(msbuildNamespace + "CLI_SharedFrameworkVersion")
+                ?.Value;
+            if (sharedFrameworkVersion == null)
+            {
+                throw new InvalidOperationException("Can't find CLI_SharedFrameworkVersion in DependencyVersions.props.");
+            }
+
+            Trace.TraceInformation($"Detected Shared Framework version '{sharedFrameworkVersion}'.");
+            return sharedFrameworkVersion;
+        }
+
+        private static string GetCommitHash(string cliVersion)
+        {
+            using (ZipArchive archive = DownloadCliInstaller(cliVersion).Result)
+            {
+                ZipArchiveEntry versionTxtEntry = archive.GetEntry($"sdk/{cliVersion}/.version");
+                if (versionTxtEntry == null)
+                {
+                    throw new InvalidOperationException("Can't find `.version` information in installer.");
+                }
+
+                using (Stream versionTxt = versionTxtEntry.Open())
+                using (var versionTxtReader = new StreamReader(versionTxt))
+                {
+                    string commitHash = versionTxtReader.ReadLine();
+                    Trace.TraceInformation($"Found commit hash '{commitHash}' in `.versions`.");
+                    return commitHash;
+                }
+            }
+        }
+
+        private static async Task<XDocument> DownloadDependencyVersions(string cliHash)
+        {
+            string downloadUrl = $"https://raw.githubusercontent.com/dotnet-bot/cli/{cliHash}/build/DependencyVersions.props";
+            Stream stream = await DownloadClient.Value.GetStreamAsync(downloadUrl);
+            return XDocument.Load(stream);
+        }
+
+        private static async Task<ZipArchive> DownloadCliInstaller(string version)
+        {
+            string downloadUrl = $"https://dotnetcli.blob.core.windows.net/dotnet/Sdk/{version}/dotnet-dev-win-x64.{version}.zip";
+            Stream nupkgStream = await DownloadClient.Value.GetStreamAsync(downloadUrl);
+            return new ZipArchive(nupkgStream);
+        }
+    }
+}

--- a/update-dependencies/CliDependencyHelper.cs
+++ b/update-dependencies/CliDependencyHelper.cs
@@ -21,7 +21,7 @@ namespace Dotnet.Docker.Nightly
 
             string cliCommitHash = GetCommitHash(cliVersion);
             XDocument depVersions = DownloadDependencyVersions(cliCommitHash).Result;
-            XNamespace msbuildNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+            XNamespace msbuildNamespace = depVersions.Document.Root.GetDefaultNamespace();
             string sharedFrameworkVersion = depVersions.Document.Root
                 .Element(msbuildNamespace + "PropertyGroup")
                 ?.Element(msbuildNamespace + "CLI_SharedFrameworkVersion")

--- a/update-dependencies/Config.cs
+++ b/update-dependencies/Config.cs
@@ -22,6 +22,7 @@ namespace Dotnet.Docker.Nightly
         private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() =>
                                                 GetEnvironmentVariable("GITHUB_PULL_REQUEST_NOTIFICATIONS", "")
                                                     .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+        private Lazy<string> _runtimeReleasePrefix = new Lazy<string>(() => Environment.GetEnvironmentVariable("RUNTIME_RELEASE_PREFIX"));
 
         private Config()
         {
@@ -39,6 +40,7 @@ namespace Dotnet.Docker.Nightly
         public string GitHubProject => _gitHubProject.Value;
         public string GitHubUpstreamBranch => _gitHubUpstreamBranch.Value;
         public string[] GitHubPullRequestNotifications => _gitHubPullRequestNotifications.Value;
+        public string RuntimeReleasePrefix => _runtimeReleasePrefix.Value ?? CliReleasePrefix;
 
         private static string GetEnvironmentVariable(string name, string defaultValue = null)
         {

--- a/update-dependencies/Program.cs
+++ b/update-dependencies/Program.cs
@@ -74,17 +74,18 @@ namespace Dotnet.Docker.Nightly
                 $"{s_config.RuntimeReleasePrefix}-{cliBuildInfo.LatestReleaseVersion}");
 
             IEnumerable<DependencyBuildInfo> buildInfos = new[]
-                {
-                    new DependencyBuildInfo(cliBuildInfo, false, Enumerable.Empty<string>()),
-                    new DependencyBuildInfo(
-                        new BuildInfo() {
-                            Name = SharedFrameworkBuildInfoName,
-                            LatestReleaseVersion = sharedFrameworkVersion,
-                            LatestPackages = new Dictionary<string, string>()
-                            },
-                        false,
-                        Enumerable.Empty<string>()),
-                };
+            {
+                new DependencyBuildInfo(cliBuildInfo, false, Enumerable.Empty<string>()),
+                new DependencyBuildInfo(
+                    new BuildInfo() 
+                    {
+                        Name = SharedFrameworkBuildInfoName,
+                        LatestReleaseVersion = sharedFrameworkVersion,
+                        LatestPackages = new Dictionary<string, string>()
+                    },
+                    false,
+                    Enumerable.Empty<string>()),
+            };
             IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
 
             return DependencyUpdateUtils.Update(updaters, buildInfos);
@@ -112,7 +113,7 @@ namespace Dotnet.Docker.Nightly
         {
             string[] dockerfiles = Directory.GetFiles(s_repoRoot, "Dockerfile", SearchOption.AllDirectories);
             return dockerfiles.Select(path => CreateSdkUpdater(path))
-                .Union(dockerfiles.Select(path => CreateRuntimeUpdater(path)));
+                .Concat(dockerfiles.Select(path => CreateRuntimeUpdater(path)));
         }
 
         private static IDependencyUpdater CreateSdkUpdater(string path)

--- a/update-dependencies/update-dependencies.csproj
+++ b/update-dependencies/update-dependencies.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.26-prerelease-00708-05" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01428-01" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
+    <PackageReference Include="NuGet.Packaging.Core.Types" Version="4.0.0" />
+    <PackageReference Include="NuGet.Packaging" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/update-dependencies/update-dependencies.csproj
+++ b/update-dependencies/update-dependencies.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01428-01" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
-    <PackageReference Include="NuGet.Packaging.Core.Types" Version="4.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="4.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm not a fan of this.  I view it as a stop-gap until the produces and consumes build tools infrastructure is in place.