### PR TITLE
Update 2.0 Dockerfiles to use new portable artifacts

### DIFF
--- a/2.0/debian/runtime/Dockerfile
+++ b/2.0/debian/runtime/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.0.0-preview1-002061-00
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-debian-x64.$DOTNET_VERSION.tar.gz
+ENV DOTNET_VERSION 2.0.0-preview2-002093-00
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-linux-x64.$DOTNET_VERSION-portable.tar.gz
 
 RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/2.0/debian/sdk/Dockerfile
+++ b/2.0/debian/sdk/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.0.0-preview2-005840
-ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+ENV DOTNET_SDK_VERSION 2.0.0-preview2-005889
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-linux-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \

--- a/2.0/nanoserver/runtime/Dockerfile
+++ b/2.0/nanoserver/runtime/Dockerfile
@@ -3,8 +3,8 @@ FROM microsoft/nanoserver:10.0.14393.1066
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core
-ENV DOTNET_VERSION 2.0.0-preview1-002061-00
-ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
+ENV DOTNET_VERSION 2.0.0-preview2-002093-00
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/master/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION-portable.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
     Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \

--- a/2.0/nanoserver/sdk/Dockerfile
+++ b/2.0/nanoserver/sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/nanoserver:10.0.14393.1066
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.0.0-preview2-005840
+ENV DOTNET_SDK_VERSION 2.0.0-preview2-005889
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
 RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \


### PR DESCRIPTION
FYI - the `-portable` suffix is supposedly going to be dropped from the runtime tarball so another update will have to happen down the road.