### PR TITLE
Produce the same tags in nightly as official

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,9 @@
         "linux": {
           "dockerfile": "1.0/runtime-deps/jessie",
           "tags": [
-            "1.0.5-runtime-deps-jessie"
+            "1.0.5-runtime-deps-jessie",
+            "1.0.5-core-deps",
+            "1.0-core-deps"
           ]
         }
       }
@@ -34,20 +36,25 @@
         "linux": {
           "dockerfile": "1.0/runtime/jessie",
           "tags": [
-            "1.0.5-runtime-jessie"
+            "1.0.5-runtime-jessie",
+            "1.0.5-core",
+            "1.0-core"
           ]
         },
         "windows": {
           "dockerfile": "1.0/runtime/nanoserver",
           "tags": [
             "1.0.5-runtime-nanoserver",
-            "1.0.5-runtime-nanoserver-10.0.14393.1198"
+            "1.0.5-runtime-nanoserver-10.0.14393.1198",
+            "1.0-runtime-nanoserver",
+            "1.0-runtime-nanoserver-10.0.14393.1198"
           ]
         }
       }
     },
     {
       "sharedTags": [
+        "1.0.5-sdk-1.0.4",
         "1.0.5-sdk",
         "1.0-sdk"
       ],
@@ -61,8 +68,12 @@
         "windows": {
           "dockerfile": "1.0/sdk/nanoserver",
           "tags": [
+            "1.0.5-sdk-1.0.4-nanoserver",
+            "1.0.5-sdk-1.0.4-nanoserver-10.0.14393.1198",
             "1.0.5-sdk-nanoserver",
-            "1.0.5-sdk-nanoserver-10.0.14393.1198"
+            "1.0.5-sdk-nanoserver-10.0.14393.1198",
+            "1.0-sdk-nanoserver",
+            "1.0-sdk-nanoserver-10.0.14393.1198"
           ]
         }
       }
@@ -78,7 +89,9 @@
         "linux": {
           "dockerfile": "1.1/runtime-deps/jessie",
           "tags": [
-            "1.1.2-runtime-deps-jessie"
+            "1.1.2-runtime-deps-jessie",
+            "1-core-deps",
+            "core-deps"
           ]
         }
       }
@@ -94,20 +107,29 @@
         "linux": {
           "dockerfile": "1.1/runtime/jessie",
           "tags": [
-            "1.1.2-runtime-jessie"
+            "1.1.2-runtime-jessie",
+            "1-core",
+            "core"
           ]
         },
         "windows": {
           "dockerfile": "1.1/runtime/nanoserver",
           "tags": [
             "1.1.2-runtime-nanoserver",
-            "1.1.2-runtime-nanoserver-10.0.14393.1198"
+            "1.1.2-runtime-nanoserver-10.0.14393.1198",
+            "1.1-runtime-nanoserver",
+            "1.1-runtime-nanoserver-10.0.14393.1198",
+            "1-runtime-nanoserver",
+            "1-runtime-nanoserver-10.0.14393.1198",
+            "runtime-nanoserver",
+            "runtime-nanoserver-10.0.14393.1198"
           ]
         }
       }
     },
     {
       "sharedTags": [
+        "1.1.2-sdk-1.0.4",
         "1.1.2-sdk",
         "1.1-sdk",
         "1-sdk",
@@ -124,8 +146,18 @@
         "windows": {
           "dockerfile": "1.1/sdk/nanoserver",
           "tags": [
+            "1.1.2-sdk-1.0.4-nanoserver",
+            "1.1.2-sdk-1.0.4-nanoserver-10.0.14393.1198",
             "1.1.2-sdk-nanoserver",
-            "1.1.2-sdk-nanoserver-10.0.14393.1198"
+            "1.1.2-sdk-nanoserver-10.0.14393.1198",
+            "1.1-sdk-nanoserver",
+            "1.1-sdk-nanoserver-10.0.14393.1198",
+            "1-sdk-nanoserver",
+            "1-sdk-nanoserver-10.0.14393.1198",
+            "sdk-nanoserver",
+            "sdk-nanoserver-10.0.14393.1198",
+            "nanoserver",
+            "nanoserver-10.0.14393.1198"
           ]
         }
       }
@@ -162,7 +194,11 @@
           "dockerfile": "2.0/runtime/nanoserver",
           "tags": [
             "2.0.0-preview1-runtime-nanoserver",
-            "2.0.0-preview1-runtime-nanoserver-10.0.14393.1198"
+            "2.0.0-preview1-runtime-nanoserver-10.0.14393.1198",
+            "2.0-runtime-nanoserver",
+            "2.0-runtime-nanoserver-10.0.14393.1198",
+            "2-runtime-nanoserver",
+            "2-runtime-nanoserver-10.0.14393.1198"
           ]
         }
       }
@@ -184,7 +220,11 @@
           "dockerfile": "2.0/sdk/nanoserver",
           "tags": [
             "2.0.0-preview1-sdk-nanoserver",
-            "2.0.0-preview1-sdk-nanoserver-10.0.14393.1198"
+            "2.0.0-preview1-sdk-nanoserver-10.0.14393.1198",
+            "2.0-sdk-nanoserver",
+            "2.0-sdk-nanoserver-10.0.14393.1198",
+            "2-sdk-nanoserver",
+            "2-sdk-nanoserver-10.0.14393.1198"
           ]
         }
       }


### PR DESCRIPTION
This is being done so that customer can more easily switch from the official repo to nightly to test the latest bits (e.g. a service fix).  This also helps ensure consistency between the official and nightly repo which helps with releases.