### PR TITLE
Misc CI script cleanup

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -6,8 +6,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$dockerRepo="microsoft/dotnet-nightly"
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
+$dockerRepo = (Get-Content "manifest.json" | ConvertFrom-Json).DockerRepo
 
 if ($UseImageCache) {
     $optionalDockerBuildArgs = ""

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -20,9 +20,9 @@ else {
     $optionalDockerBuildArgs = "--no-cache"
 }
 
-$dockerRepo = "microsoft/dotnet-nightly"
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
+$dockerRepo = (Get-Content "${repoRoot}${dirSeparator}manifest.json" | ConvertFrom-Json).DockerRepo
 $testFilesPath = "$PSScriptRoot$dirSeparator"
 $platform = docker version -f "{{ .Server.Os }}"
 
@@ -85,10 +85,10 @@ Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
             if ($platform -eq "linux") {
                 $selfContainedImage = "self-contained-build-${buildImage}"
                 $optionalRestoreParams = ""
-                if ($sdkTag -like "2.0-sdk") {
-                    # Temporary workaround until 2.0 packages are released on NuGet.org
-                    $optionalRestoreParams = "-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json"
-                }
+                # Enable and update as appropriate whenever pre-release packages are referenced prior to being available on NuGet.org.
+                # if ($sdkTag -like "<???>-sdk") {
+                #     $optionalRestoreParams = "-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json"
+                # }
 
                 Write-Host "----- Creating publish-image for self-contained app built on $fullSdkTag -----"
                 Try {


### PR DESCRIPTION
- Updated CI scripts to read Docker Hub repo info from manifest.  This makes it easier to test changes when you want to build and push to a private repo.
- Disabled the NuGet package workaround for when packages aren't yet available on NuGet.org.

