### PR TITLE
Upgrade to latest image builder

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -7,7 +7,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
-$dockerRepo = (Get-Content "manifest.json" | ConvertFrom-Json).DockerRepo
+$dockerRepo = (Get-Content "manifest.json" | ConvertFrom-Json).Repos[0].Name
 
 if ($UseImageCache) {
     $optionalDockerBuildArgs = ""

--- a/build-pipeline/dotnet-docker-linux-images.json
+++ b/build-pipeline/dotnet-docker-linux-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170522095246"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -8,17 +8,15 @@
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
+        "filename": "docker",
+        "arguments": "system prune -a -f",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
+        "failOnStandardError": "false"
       }
     },
     {
@@ -44,7 +42,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Create container",
+      "displayName": "Publish Manifest",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -54,7 +52,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.publishManifest.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -63,28 +61,9 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Copy image-builder locally",
+      "displayName": "Update Readme",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/out $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Cleanup container",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
       "task": {
         "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
@@ -92,26 +71,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "rmi -f $(image-builder.imageName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Run image-builder",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
-        "arguments": "$(image-builder.args)",
+        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.updateReadme.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -124,17 +84,15 @@
       "timeoutInMinutes": 0,
       "condition": "always()",
       "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
+        "filename": "docker",
+        "arguments": "system prune -a -f",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
+        "failOnStandardError": "false"
       }
     }
   ],
@@ -183,14 +141,22 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170522095246"
     },
-    "image-builder.args": {
-      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
+    "image-builder.common.args": {
+      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
+      "allowOverride": true
+    },
+    "image-builder.publishManifest.args": {
+      "value": "--command PublishManifest $(image-builder.common.args)",
+      "allowOverride": true
+    },
+    "image-builder.updateReadme.args": {
+      "value": "--command UpdateReadme $(image-builder.common.args)",
       "allowOverride": true
     },
     "image-builder.containerName": {
-      "value": "dotnet-docker-nightly-linux-$(Build.BuildId)"
+      "value": "dotnet-docker-nightly-post-image-build-$(Build.BuildId)"
     },
     "PB.docker.password": {
       "value": null,
@@ -198,7 +164,7 @@
     }
   },
   "demands": [
-    "Agent.OS -equals Windows_NT"
+    "Agent.OS -equals linux"
   ],
   "retentionRules": [
     {
@@ -221,7 +187,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "1",
+      "cleanOptions": "0",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",
@@ -238,22 +204,22 @@
     "name": "dotnet/dotnet-docker-nightly",
     "url": "https://github.com/dotnet/dotnet-docker-nightly.git",
     "defaultBranch": "master",
-    "clean": "true",
+    "clean": "false",
     "checkoutSubmodules": false
   },
   "processParameters": {},
   "quality": "definition",
   "queue": {
-    "id": 159,
-    "name": "DotNetCore-Test",
+    "id": 36,
+    "name": "DotNet-Build",
     "pool": {
-      "id": 83,
-      "name": "DotNetCore-Test"
+      "id": 39,
+      "name": "DotNet-Build"
     }
   },
-  "id": 6216,
-  "name": "dotnet-docker-nightly-windows-images",
-  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
+  "id": 6218,
+  "name": "dotnet-docker-nightly-post-image-build",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
   "path": "\\",
   "type": "build",
   "project": {

--- a/build-pipeline/dotnet-docker-windows-images.json
+++ b/build-pipeline/dotnet-docker-windows-images.json
@@ -8,15 +8,17 @@
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "system prune -a -f",
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
         "workingFolder": "",
-        "failOnStandardError": "false"
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
       }
     },
     {
@@ -42,7 +44,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Publish Manifest",
+      "displayName": "Create container",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -52,7 +54,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.publishManifest.args)",
+        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -61,7 +63,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Update Readme",
+      "displayName": "Copy image-builder locally",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -70,8 +72,46 @@
         "definitionType": "task"
       },
       "inputs": {
+        "filename": "docker ",
+        "arguments": "cp $(image-builder.containerName):/out $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Cleanup container",
+      "timeoutInMinutes": 0,
+      "condition": "always()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo --name $(image-builder.containerName) $(image-builder.imageName) $(image-builder.updateReadme.args)",
+        "arguments": "rmi -f $(image-builder.imageName)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run image-builder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
+        "arguments": "$(image-builder.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -84,15 +124,17 @@
       "timeoutInMinutes": 0,
       "condition": "always()",
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
         "versionSpec": "1.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "system prune -a -f",
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
         "workingFolder": "",
-        "failOnStandardError": "false"
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "failOnStandardError": "true"
       }
     }
   ],
@@ -141,22 +183,14 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170522094128"
     },
-    "image-builder.common.args": {
-      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
-      "allowOverride": true
-    },
-    "image-builder.publishManifest.args": {
-      "value": "--command PublishManifest $(image-builder.common.args)",
-      "allowOverride": true
-    },
-    "image-builder.updateReadme.args": {
-      "value": "--command UpdateReadme $(image-builder.common.args)",
+    "image-builder.args": {
+      "value": "--command build --manifest manifest.json --push --username $(PB.docker.username) --password $(PB.docker.password)",
       "allowOverride": true
     },
     "image-builder.containerName": {
-      "value": "dotnet-docker-nightly-linux-$(Build.BuildId)"
+      "value": "dotnet-docker-nightly-windows-$(Build.BuildId)"
     },
     "PB.docker.password": {
       "value": null,
@@ -164,7 +198,7 @@
     }
   },
   "demands": [
-    "Agent.OS -equals linux"
+    "Agent.OS -equals Windows_NT"
   ],
   "retentionRules": [
     {
@@ -187,7 +221,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "0",
+      "cleanOptions": "1",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",
@@ -204,22 +238,22 @@
     "name": "dotnet/dotnet-docker-nightly",
     "url": "https://github.com/dotnet/dotnet-docker-nightly.git",
     "defaultBranch": "master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},
   "quality": "definition",
   "queue": {
-    "id": 36,
-    "name": "DotNet-Build",
+    "id": 159,
+    "name": "DotNetCore-Test",
     "pool": {
-      "id": 39,
-      "name": "DotNet-Build"
+      "id": 83,
+      "name": "DotNetCore-Test"
     }
   },
-  "id": 6218,
-  "name": "dotnet-docker-nightly-manifest",
-  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6218",
+  "id": 6216,
+  "name": "dotnet-docker-nightly-windows-images",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6216",
   "path": "\\",
   "type": "build",
   "project": {

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -14,7 +14,7 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-nightly-linux-images"
+          "Name": "dotnet-docker-linux-images"
         }
       ]
     },
@@ -25,7 +25,7 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-nightly-windows-images"
+          "Name": "dotnet-docker-windows-images"
         }
       ]
     },
@@ -36,7 +36,7 @@
       },
       "Definitions": [
         {
-          "Name": "dotnet-docker-nightly-post-image-build"
+          "Name": "dotnet-docker-post-image-build"
         }
       ],
       "DependsOn": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
-  "DockerRepo": "microsoft/dotnet-nightly",
-  "ReadmePath": "README.md",
-  "TestCommands": {
+  "tagVariables": {
+    "nanoServerVersion": "10.0.14393.1198"
+  },
+  "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .",
       "docker run -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File ./test/run-test.ps1"
@@ -10,224 +11,230 @@
       "powershell -NoProfile -Command .\\test\\run-test.ps1"
     ]
   },
-  "Images": [
+  "repos": [
     {
-      "sharedTags": [
-        "1.0.5-runtime-deps",
-        "1.0-runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/runtime-deps/jessie",
-          "tags": [
-            "1.0.5-runtime-deps-jessie",
-            "1.0.5-core-deps",
-            "1.0-core-deps"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.0.5-runtime",
-        "1.0-runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/runtime/jessie",
-          "tags": [
-            "1.0.5-runtime-jessie",
-            "1.0.5-core",
-            "1.0-core"
-          ]
+      "name": "microsoft/dotnet-nightly",
+      "readmePath": "README.md",
+      "images": [
+        {
+          "sharedTags": [
+            "1.0.5-runtime-deps",
+            "1.0-runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/runtime-deps/jessie",
+              "tags": [
+                "1.0.5-runtime-deps-jessie",
+                "1.0.5-core-deps",
+                "1.0-core-deps"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.0/runtime/nanoserver",
-          "tags": [
-            "1.0.5-runtime-nanoserver",
-            "1.0.5-runtime-nanoserver-10.0.14393.1198",
-            "1.0-runtime-nanoserver",
-            "1.0-runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.0.5-sdk-1.0.4",
-        "1.0.5-sdk",
-        "1.0-sdk"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.0/sdk/jessie",
-          "tags": [
-            "1.0.5-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.0.5-runtime",
+            "1.0-runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/runtime/jessie",
+              "tags": [
+                "1.0.5-runtime-jessie",
+                "1.0.5-core",
+                "1.0-core"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/runtime/nanoserver",
+              "tags": [
+                "1.0.5-runtime-nanoserver",
+                "1.0.5-runtime-nanoserver-$(nanoServerVersion)",
+                "1.0-runtime-nanoserver",
+                "1.0-runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.0/sdk/nanoserver",
-          "tags": [
-            "1.0.5-sdk-1.0.4-nanoserver",
-            "1.0.5-sdk-1.0.4-nanoserver-10.0.14393.1198",
-            "1.0.5-sdk-nanoserver",
-            "1.0.5-sdk-nanoserver-10.0.14393.1198",
-            "1.0-sdk-nanoserver",
-            "1.0-sdk-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-runtime-deps",
-        "1.1-runtime-deps",
-        "1-runtime-deps",
-        "runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/runtime-deps/jessie",
-          "tags": [
-            "1.1.2-runtime-deps-jessie",
-            "1-core-deps",
-            "core-deps"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-runtime",
-        "1.1-runtime",
-        "1-runtime",
-        "runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/runtime/jessie",
-          "tags": [
-            "1.1.2-runtime-jessie",
-            "1-core",
-            "core"
-          ]
+        {
+          "sharedTags": [
+            "1.0.5-sdk-1.0.4",
+            "1.0.5-sdk",
+            "1.0-sdk"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.0/sdk/jessie",
+              "tags": [
+                "1.0.5-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.0/sdk/nanoserver",
+              "tags": [
+                "1.0.5-sdk-1.0.4-nanoserver",
+                "1.0.5-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
+                "1.0.5-sdk-nanoserver",
+                "1.0.5-sdk-nanoserver-$(nanoServerVersion)",
+                "1.0-sdk-nanoserver",
+                "1.0-sdk-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.1/runtime/nanoserver",
-          "tags": [
-            "1.1.2-runtime-nanoserver",
-            "1.1.2-runtime-nanoserver-10.0.14393.1198",
-            "1.1-runtime-nanoserver",
-            "1.1-runtime-nanoserver-10.0.14393.1198",
-            "1-runtime-nanoserver",
-            "1-runtime-nanoserver-10.0.14393.1198",
-            "runtime-nanoserver",
-            "runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "1.1.2-sdk-1.0.4",
-        "1.1.2-sdk",
-        "1.1-sdk",
-        "1-sdk",
-        "sdk",
-        "latest"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "1.1/sdk/jessie",
-          "tags": [
-            "1.1.2-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-runtime-deps",
+            "1.1-runtime-deps",
+            "1-runtime-deps",
+            "runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/runtime-deps/jessie",
+              "tags": [
+                "1.1.2-runtime-deps-jessie",
+                "1-core-deps",
+                "core-deps"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "1.1/sdk/nanoserver",
-          "tags": [
-            "1.1.2-sdk-1.0.4-nanoserver",
-            "1.1.2-sdk-1.0.4-nanoserver-10.0.14393.1198",
-            "1.1.2-sdk-nanoserver",
-            "1.1.2-sdk-nanoserver-10.0.14393.1198",
-            "1.1-sdk-nanoserver",
-            "1.1-sdk-nanoserver-10.0.14393.1198",
-            "1-sdk-nanoserver",
-            "1-sdk-nanoserver-10.0.14393.1198",
-            "sdk-nanoserver",
-            "sdk-nanoserver-10.0.14393.1198",
-            "nanoserver",
-            "nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview2-runtime-deps",
-        "2.0-runtime-deps",
-        "2-runtime-deps"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/runtime-deps/jessie",
-          "tags": [
-            "2.0.0-preview2-runtime-deps-jessie"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview2-runtime",
-        "2.0-runtime",
-        "2-runtime"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/runtime/jessie",
-          "tags": [
-            "2.0.0-preview2-runtime-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-runtime",
+            "1.1-runtime",
+            "1-runtime",
+            "runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/runtime/jessie",
+              "tags": [
+                "1.1.2-runtime-jessie",
+                "1-core",
+                "core"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/runtime/nanoserver",
+              "tags": [
+                "1.1.2-runtime-nanoserver",
+                "1.1.2-runtime-nanoserver-$(nanoServerVersion)",
+                "1.1-runtime-nanoserver",
+                "1.1-runtime-nanoserver-$(nanoServerVersion)",
+                "1-runtime-nanoserver",
+                "1-runtime-nanoserver-$(nanoServerVersion)",
+                "runtime-nanoserver",
+                "runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "2.0/runtime/nanoserver",
-          "tags": [
-            "2.0.0-preview2-runtime-nanoserver",
-            "2.0.0-preview2-runtime-nanoserver-10.0.14393.1198",
-            "2.0-runtime-nanoserver",
-            "2.0-runtime-nanoserver-10.0.14393.1198",
-            "2-runtime-nanoserver",
-            "2-runtime-nanoserver-10.0.14393.1198"
-          ]
-        }
-      }
-    },
-    {
-      "sharedTags": [
-        "2.0.0-preview2-sdk",
-        "2.0-sdk",
-        "2-sdk"
-      ],
-      "platforms": {
-        "linux": {
-          "dockerfile": "2.0/sdk/jessie",
-          "tags": [
-            "2.0.0-preview2-sdk-jessie"
-          ]
+        {
+          "sharedTags": [
+            "1.1.2-sdk-1.0.4",
+            "1.1.2-sdk",
+            "1.1-sdk",
+            "1-sdk",
+            "sdk",
+            "latest"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "1.1/sdk/jessie",
+              "tags": [
+                "1.1.2-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "1.1/sdk/nanoserver",
+              "tags": [
+                "1.1.2-sdk-1.0.4-nanoserver",
+                "1.1.2-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
+                "1.1.2-sdk-nanoserver",
+                "1.1.2-sdk-nanoserver-$(nanoServerVersion)",
+                "1.1-sdk-nanoserver",
+                "1.1-sdk-nanoserver-$(nanoServerVersion)",
+                "1-sdk-nanoserver",
+                "1-sdk-nanoserver-$(nanoServerVersion)",
+                "sdk-nanoserver",
+                "sdk-nanoserver-$(nanoServerVersion)",
+                "nanoserver",
+                "nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         },
-        "windows": {
-          "dockerfile": "2.0/sdk/nanoserver",
-          "tags": [
-            "2.0.0-preview2-sdk-nanoserver",
-            "2.0.0-preview2-sdk-nanoserver-10.0.14393.1198",
-            "2.0-sdk-nanoserver",
-            "2.0-sdk-nanoserver-10.0.14393.1198",
-            "2-sdk-nanoserver",
-            "2-sdk-nanoserver-10.0.14393.1198"
-          ]
+        {
+          "sharedTags": [
+            "2.0.0-preview2-runtime-deps",
+            "2.0-runtime-deps",
+            "2-runtime-deps"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime-deps/jessie",
+              "tags": [
+                "2.0.0-preview2-runtime-deps-jessie"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview2-runtime",
+            "2.0-runtime",
+            "2-runtime"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime/jessie",
+              "tags": [
+                "2.0.0-preview2-runtime-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/runtime/nanoserver",
+              "tags": [
+                "2.0.0-preview2-runtime-nanoserver",
+                "2.0.0-preview2-runtime-nanoserver-$(nanoServerVersion)",
+                "2.0-runtime-nanoserver",
+                "2.0-runtime-nanoserver-$(nanoServerVersion)",
+                "2-runtime-nanoserver",
+                "2-runtime-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
+        },
+        {
+          "sharedTags": [
+            "2.0.0-preview2-sdk",
+            "2.0-sdk",
+            "2-sdk"
+          ],
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/sdk/jessie",
+              "tags": [
+                "2.0.0-preview2-sdk-jessie"
+              ]
+            },
+            "windows": {
+              "dockerfile": "2.0/sdk/nanoserver",
+              "tags": [
+                "2.0.0-preview2-sdk-nanoserver",
+                "2.0.0-preview2-sdk-nanoserver-$(nanoServerVersion)",
+                "2.0-sdk-nanoserver",
+                "2.0-sdk-nanoserver-$(nanoServerVersion)",
+                "2-sdk-nanoserver",
+                "2-sdk-nanoserver-$(nanoServerVersion)"
+              ]
+            }
+          }
         }
-      }
+      ]
     }
   ]
 }

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -23,7 +23,7 @@ else {
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $manifestPath = [IO.Path]::combine(${repoRoot}, "manifest.json")
-$dockerRepo = (Get-Content $manifestPath | ConvertFrom-Json).DockerRepo
+$dockerRepo = (Get-Content $manifestPath | ConvertFrom-Json).Repos[0].Name
 $testFilesPath = "$PSScriptRoot$dirSeparator"
 $platform = docker version -f "{{ .Server.Os }}"
 


### PR DESCRIPTION
- Upgraded to use latest image builder tool.  This required a manifest schema change.  
- Refactored manifest to make use of tagVariables which will make patch Tuesday work easier/less error prone.
- Renamed build-pipeline build definitions to align with the dotnet-docker repo.  This makes merging changes easier.