### PR TITLE
Add debian:stretch based Dockerfiles for 2.0

### DIFF
--- a/2.0/runtime-deps/stretch/Dockerfile
+++ b/2.0/runtime-deps/stretch/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        \
+# .NET Core dependencies
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*

--- a/2.0/runtime/stretch/Dockerfile
+++ b/2.0/runtime/stretch/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/dotnet-nightly:2.0-runtime-deps-stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core
+ENV DOTNET_VERSION 2.0.0-preview2-25324-03
+ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz
+ENV DOTNET_DOWNLOAD_SHA 39F4BCF5B84E8DA34C56F24429EE46275529BE107117E9608D89680CE028EB46DEA4FCE2BB65695C1DCE1B4053369D8D866676AD6587BBDD4FC5DB3476FD9C81
+
+RUN curl -SL $DOTNET_DOWNLOAD_URL --output dotnet.tar.gz \
+    && echo "$DOTNET_DOWNLOAD_SHA dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/2.0/sdk/stretch/Dockerfile
+++ b/2.0/sdk/stretch/Dockerfile
@@ -1,0 +1,38 @@
+FROM buildpack-deps:stretch-scm
+
+# Install .NET CLI dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.0-preview2-006215
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-$DOTNET_SDK_VERSION-linux-x64.tar.gz
+ENV DOTNET_SDK_DOWNLOAD_SHA FD49805501F052325C7EE93FBB5C86EADC90AA1510F25E2FFC13646BA7EAC8E1C236D84646624E753D7D2A270B323FEF80EE1547C3ECA49F2E547BDFB1933670
+
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && echo "$DOTNET_SDK_DOWNLOAD_SHA dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+    && rm -rf /tmp/NuGetScratch

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 - `2.0.0-preview2-runtime`, `2.0-runtime`, `2-runtime`:
     - [`2.0.0-preview2-runtime-jessie` (*2.0/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/jessie/Dockerfile)
     - [`2.0.0-preview2-runtime-nanoserver` (*2.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/Dockerfile)
+- [`2.0.0-preview2-runtime-stretch`, `2.0-runtime-stretch`, `2-runtime-stretch` (*2.0/runtime/stretch/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/stretch/Dockerfile)
 - `2.0.0-preview2-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`:
     - [`2.0.0-preview2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime-deps/jessie/Dockerfile)
+- [`2.0.0-preview2-runtime-deps-stretch`, `2.0-runtime-deps-stretch`, `2-runtime-deps-stretch`  (*2.0/runtime-deps/stretch/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime-deps/stretch/Dockerfile)
 - `2.0.0-preview2-sdk`, `2.0-sdk`, `2-sdk`:
     - [`2.0.0-preview2-sdk-jessie` (*2.0/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/jessie/Dockerfile)
     - [`2.0.0-preview2-sdk-nanoserver` (*2.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/Dockerfile)
+- [`2.0.0-preview2-sdk-stretch`, `2.0-sdk-stretch`, `2-sdk-stretch` (*2.0/sdk/stretch/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/stretch/Dockerfile)
 
 For more information about these images and their history, please see [the relevant Dockerfile (`dotnet/dotnet-docker-nightly`)](https://github.com/dotnet/dotnet-docker-nightly/search?utf8=%E2%9C%93&q=FROM&type=Code). These images are updated via [pull requests to the `dotnet/dotnet-docker-nightly` GitHub repo](https://github.com/dotnet/dotnet-docker-nightly/pulls?utf8=%E2%9C%93&q=).
 

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -16,12 +16,12 @@ else {
 $manifest = Get-Content "manifest.json" | ConvertFrom-Json
 $manifestRepo = $manifest.Repos[0]
 $platform = docker version -f "{{ .Server.Os }}"
-$builtTags = [System.Collections.ArrayList]@()
+$builtTags = @()
 
 $manifestRepo.Images |
     ForEach-Object {
         $images = $_
-        ForEach-Object {$_.Platforms} |
+        $_.Platforms |
             Where-Object {[bool]($_.PSobject.Properties.name -match $platform)} |
             ForEach-Object {
                 $dockerfilePath = $_.$platform.dockerfile
@@ -31,8 +31,7 @@ $manifestRepo.Images |
                 }
 
                 $qualifiedTags = $tags | ForEach-Object {
-                    $_ = $manifestRepo.Name + ':' + $_.Replace('$(nanoServerVersion)', $manifest.TagVariables.NanoServerVersion)
-                    $_
+                    $manifestRepo.Name + ':' + $_.Replace('$(nanoServerVersion)', $manifest.TagVariables.NanoServerVersion)
                 }
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"
@@ -41,7 +40,7 @@ $manifestRepo.Images |
                     throw "Failed building $formattedTags"
                 }
 
-                $builtTags.Add($formattedTags) | Out-Null
+                $builtTags += $formattedTags
             }
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -233,6 +233,42 @@
               ]
             }
           }
+        },
+        {
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime-deps/stretch",
+              "tags": [
+                "2.0.0-preview2-runtime-deps-stretch",
+                "2.0-runtime-deps-stretch",
+                "2-runtime-deps-stretch"
+              ]
+            }
+          }
+        },
+        {
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/runtime/stretch",
+              "tags": [
+                "2.0.0-preview2-runtime-stretch",
+                "2.0-runtime-stretch",
+                "2-runtime-stretch"
+              ]
+            }
+          }
+        },
+        {
+          "platforms": {
+            "linux": {
+              "dockerfile": "2.0/sdk/stretch",
+              "tags": [
+                "2.0.0-preview2-sdk-stretch",
+                "2.0-sdk-stretch",
+                "2-sdk-stretch"
+              ]
+            }
+          }
         }
       ]
     }

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -3,6 +3,9 @@ param(
     [switch]$UseImageCache
 )
 
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
 function Exec([scriptblock]$cmd, [string]$errorMessage = "Error executing command: " + $cmd) {
     & $cmd
     if ($LastExitCode -ne 0) {
@@ -10,11 +13,21 @@ function Exec([scriptblock]$cmd, [string]$errorMessage = "Error executing comman
     }
 }
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+function Get-ActivePlatformImages([PSCustomObject]$manifestRepo, [string]$platform) {
+    return $manifestRepo.Images |
+        ForEach-Object {$_.Platforms} |
+        Where-Object {[bool]($_.PSobject.Properties.name -match $platform)}
+}
+
+function Get-RuntimeTag([string]$sdkDockerfilePath, [string]$runtimeType, [string]$platform, [PSCustomObject]$manifestRepo) {
+    $runtimeDockerfilePath = $sdkDockerfilePath.Replace("sdk", $runtimeType)
+    $platforms = Get-ActivePlatformImages $manifestRepo $platform |
+        Where-Object {$_.$platform.Dockerfile -eq $runtimeDockerfilePath}
+    return $manifestRepo.Name + ':' + $platforms[0].$platform.Tags[0]
+}
 
 if ($UseImageCache) {
-    $optionalDockerBuildArgs=""
+    $optionalDockerBuildArgs = ""
 }
 else {
     $optionalDockerBuildArgs = "--no-cache"
@@ -23,38 +36,33 @@ else {
 $dirSeparator = [IO.Path]::DirectorySeparatorChar
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $manifestPath = [IO.Path]::combine(${repoRoot}, "manifest.json")
-$dockerRepo = (Get-Content $manifestPath | ConvertFrom-Json).Repos[0].Name
+$manifestRepo = (Get-Content $manifestPath | ConvertFrom-Json).Repos[0]
 $testFilesPath = "$PSScriptRoot$dirSeparator"
 $platform = docker version -f "{{ .Server.Os }}"
 
 # update as appropriate (e.g. "2.0-sdk") whenever pre-release packages are referenced prior to being available on NuGet.org.
-$includePrereleasePackageSourceForSdkTag = "2.0-sdk"
+$includePrereleasePackageSourceForSdkTag = "2.0*-sdk*"
 
 if ($platform -eq "windows") {
-    $imageOs = "nanoserver"
     $containerRoot = "C:\"
     $platformDirSeparator = '\'
 }
 else {
-    $imageOs = "jessie"
     $containerRoot = "/"
     $platformDirSeparator = '/'
 }
 
 # Loop through each sdk Dockerfile in the repo and test the sdk and runtime images.
-Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
-    where DirectoryName -like "*${dirSeparator}sdk${dirSeparator}${imageOs}" |
-    foreach {
-        $sdkTag = $_.DirectoryName.
-                Replace("$repoRoot$dirSeparator", '').
-                Replace("$dirSeparator$imageOs", '').
-                Replace($dirSeparator, '-')
-        $fullSdkTag = "${dockerRepo}:${sdkTag}"
+Get-ActivePlatformImages $manifestRepo $platform |
+    Where-Object {$_.$platform.Dockerfile.Contains('sdk')} |
+    ForEach-Object {
+        $sdkTag = $_.$platform.Tags[0]
+        $fullSdkTag = "$($manifestRepo.Name):${sdkTag}"
 
         $timeStamp = Get-Date -Format FileDateTime
         $appName = "app$timeStamp".ToLower()
         $buildImage = "sdk-build-$appName"
-        $dotnetNewParam = "console --framework netcoreapp$($sdkTag.Split('-')[0])"
+        $dotnetNewParam = "console --framework netcoreapp$($sdkTag.Split('-')[0].Substring(0,3))"
 
         $optionalRestoreParams = ""
         if ($sdkTag -like $includePrereleasePackageSourceForSdkTag) {
@@ -82,11 +90,11 @@ Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
                     dotnet publish -o ${containerRoot}volume
                 }
 
-                $runtimeTag = $fullSdkTag.Replace("sdk", "runtime")
-                Write-Host "----- Testing on $runtimeTag with $sdkTag framework-dependent app -----"
+                $fullRuntimeTag = Get-RuntimeTag $_.$platform.Dockerfile "runtime" $platform $manifestRepo
+                Write-Host "----- Testing on $fullRuntimeTag with $sdkTag framework-dependent app -----"
                 exec { docker run --rm `
                     -v ${framworkDepVol}":${containerRoot}volume" `
-                    "$runtimeTag" `
+                    "$fullRuntimeTag" `
                     dotnet "${containerRoot}volume${platformDirSeparator}test.dll"
                 }
             }
@@ -113,7 +121,7 @@ Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
                             dotnet publish -r debian.8-x64 -o ${containerRoot}volume
                         }
 
-                        if ($sdkTag -like "2.0-sdk") {
+                        if ($sdkTag -like "2.0*-sdk*") {
                             # Temporary workaround https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/dogfooding.md#option-2-self-contained
                             exec { docker run --rm `
                                 -v ${selfContainedVol}":${containerRoot}volume" `
@@ -122,11 +130,11 @@ Get-ChildItem -Path $repoRoot -Recurse -Filter Dockerfile |
                             }
                         }
 
-                        $runtimeDepsTag = $fullSdkTag.Replace("sdk", "runtime-deps")
-                        Write-Host "----- Testing $runtimeDepsTag with $sdkTag self-contained app -----"
+                        $fullRuntimeDepsTag = Get-RuntimeTag $_.$platform.Dockerfile "runtime-deps" $platform $manifestRepo
+                        Write-Host "----- Testing $fullRuntimeDepsTag with $sdkTag self-contained app -----"
                         exec { docker run -t --rm `
                             -v ${selfContainedVol}":${containerRoot}volume" `
-                            $runtimeDepsTag `
+                            $fullRuntimeDepsTag `
                             ${containerRoot}volume${platformDirSeparator}test
                         }
                     }


### PR DESCRIPTION
1. Added new Debian Stretch based Dockerfiles for 2.0
2. Updated CI scripts to read manifest in order to determine what to build/test.  I would eventually like to remove the build script and replace it with the image-builder tool but that is currently blocked on some Windows/Docker issues.