### PR TITLE
Add missing repo filter to publishManifest build leg

### DIFF
--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -144,7 +144,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170710090943"
     },
     "image-builder.common.args": {
-      "value": "--manifest manifest.json --username $(PB.docker.username) --password $(PB.docker.password)",
+      "value": "--manifest manifest.json --repo microsoft/dotnet-nightly --username $(PB.docker.username) --password $(PB.docker.password)",
       "allowOverride": true
     },
     "image-builder.publishManifest.args": {


### PR DESCRIPTION
This was an oversight on https://github.com/dotnet/dotnet-docker-nightly/pull/355.  This doesn't cause a functional issue other than the multi-arch tags are getting re-pushed in the insider repo unnecessarily.