### PR TITLE
Update broken dockerfile paths in readme

### DIFF
--- a/2.0/runtime/nanoserver-insider/README.md
+++ b/2.0/runtime/nanoserver-insider/README.md
@@ -7,8 +7,8 @@ Please be sure to use a build from either the [Windows Server Insider Preview](h
 Read more about the changes coming to Nano Server in future releases of Windows Server [here](https://docs.microsoft.com/en-us/windows-server/get-started/nano-in-semi-annual-channel).
 
 # Supported Windows tags
- - [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-insider/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver-insider/Dockerfile)
- - [`2.0.0-sdk-nanoserver`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `latest` (*2.0/sdk/nanoserver-insider/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver-insider/Dockerfile)
+- [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver-insider/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver-insider/amd64/Dockerfile)
+- [`2.0.0-sdk-nanoserver`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver-insider/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver-insider/amd64/Dockerfile)
 
 # What is .NET Core?
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 - [`1.1.2-runtime-deps-jessie`, `1.1.2-runtime-deps`, `1.1-runtime-deps`, `1-runtime-deps` (*1.1/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime-deps/jessie/Dockerfile)
 - [`1.1.2-sdk-jessie`, `1.1.2-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/jessie/Dockerfile)
 - [`2.0.0-runtime-stretch`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/stretch/amd64/Dockerfile)
-- [`2.0.0-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/jessie/Dockerfile)
+- [`2.0.0-runtime-jessie`, `2.0-runtime-jessie`, `2-runtime-jessie` (*2.0/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/jessie/amd64/Dockerfile)
 - [`2.0.0-runtime-deps-stretch`, `2.0.0-runtime-deps`, `2.0-runtime-deps`, `2-runtime-deps`, `runtime-deps` (*2.0/runtime-deps/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime-deps/stretch/amd64/Dockerfile)
-- [`2.0.0-runtime-deps-jessie`, `2.0-runtime-deps-jessie`, `2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime-deps/jessie/Dockerfile)
-- [`2.0.0-sdk-stretch`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/stretch/Dockerfile)
-- [`2.0.0-sdk-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/jessie/Dockerfile)
+- [`2.0.0-runtime-deps-jessie`, `2.0-runtime-deps-jessie`, `2-runtime-deps-jessie` (*2.0/runtime-deps/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime-deps/jessie/amd64/Dockerfile)
+- [`2.0.0-sdk-stretch`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/stretch/amd64/Dockerfile)
+- [`2.0.0-sdk-jessie`, `2.0-sdk-jessie`, `2-sdk-jessie` (*2.0/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/jessie/amd64/Dockerfile)
 
 # Supported Windows amd64 tags
 
@@ -23,8 +23,8 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 - [`1.0.5-sdk-nanoserver`, `1.0.5-sdk`, `1.0-sdk` (*1.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/sdk/nanoserver/Dockerfile)
 - [`1.1.2-runtime-nanoserver`, `1.1.2-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime/nanoserver/Dockerfile)
 - [`1.1.2-sdk-nanoserver`, `1.1.2-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/nanoserver/Dockerfile)
-- [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/Dockerfile)
-- [`2.0.0-sdk-nanoserver`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/Dockerfile)
+- [`2.0.0-runtime-nanoserver`, `2.0.0-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
+- [`2.0.0-sdk-nanoserver`, `2.0.0-sdk`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -30,13 +30,13 @@ $manifestRepo.Images |
                 -or ( [bool]($_.PSobject.Properties.name -match "architecture") -and $_.architecture -eq "$Architecture" ) } |
             ForEach-Object {
                 $dockerfilePath = $_.dockerfile
-                $tags = $_.Tags
-                if ([bool]($images.PSobject.Properties.name -match "sharedTags")) {
-                    $tags += $images.sharedTags
+                $tags = [array]($_.Tags | ForEach-Object { $_.PSobject.Properties })
+                if ([bool]($images.PSobject.Properties.name -match "sharedtags")) {
+                    $tags += [array]($images.sharedtags | ForEach-Object { $_.PSobject.Properties })
                 }
 
                 $qualifiedTags = $tags | ForEach-Object {
-                    $manifestRepo.Name + ':' + $_.Replace('$(nanoServerVersion)', $manifest.TagVariables.NanoServerVersion)
+                    $manifestRepo.Name + ':' + $_.name.Replace('$(nanoServerVersion)', $manifest.TagVariables.NanoServerVersion)
                 }
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"

--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170728152008"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170804090915"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -176,7 +176,7 @@
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170728152008"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170804090915"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170728152008"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170804090915"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --repo microsoft/dotnet-nightly --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-amd64-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170728151701"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170804091402"
     },
     "image-builder.args": {
       "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/manifest.json
+++ b/manifest.json
@@ -17,296 +17,408 @@
       "readmePath": "README.md",
       "images": [
         {
-          "sharedTags": [
-            "1.0.5-runtime-deps",
-            "1.0-runtime-deps"
-          ],
+          "readmeOrder": 1,
+          "sharedTags": {
+            "1.0.5-runtime-deps": {},
+            "1.0-runtime-deps": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.0/runtime-deps/jessie",
               "os": "linux",
-              "tags": [
-                "1.0.5-runtime-deps-jessie",
-                "1.0.5-core-deps",
-                "1.0-core-deps"
-              ]
+              "tags": {
+                "1.0.5-runtime-deps-jessie": {},
+                "1.0.5-core-deps": {
+                  "isUndocumented": true
+                },
+                "1.0-core-deps": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "1.0.5-runtime",
-            "1.0-runtime"
-          ],
+          "readmeOrder": 0,
+          "sharedTags": {
+            "1.0.5-runtime": {},
+            "1.0-runtime": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.0/runtime/jessie",
               "os": "linux",
-              "tags": [
-                "1.0.5-runtime-jessie",
-                "1.0.5-core",
-                "1.0-core"
-              ]
+              "tags": {
+                "1.0.5-runtime-jessie": {},
+                "1.0.5-core": {
+                  "isUndocumented": true
+                },
+                "1.0-core": {
+                  "isUndocumented": true
+                }
+              }
             },
             {
               "dockerfile": "1.0/runtime/nanoserver",
               "os": "windows",
-              "tags": [
-                "1.0.5-runtime-nanoserver",
-                "1.0.5-runtime-nanoserver-$(nanoServerVersion)",
-                "1.0-runtime-nanoserver",
-                "1.0-runtime-nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "1.0.5-runtime-nanoserver": {},
+                "1.0.5-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.0-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.0-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "1.0.5-sdk-1.0.4",
-            "1.0.5-sdk",
-            "1.0-sdk"
-          ],
+          "readmeOrder": 2,
+          "sharedTags": {
+            "1.0.5-sdk-1.0.4": {
+              "isUndocumented": true
+            },
+            "1.0.5-sdk": {},
+            "1.0-sdk": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.0/sdk/jessie",
               "os": "linux",
-              "tags": [
-                "1.0.5-sdk-jessie"
-              ]
+              "tags": {
+                "1.0.5-sdk-jessie": {}
+              }
             },
             {
               "dockerfile": "1.0/sdk/nanoserver",
               "os": "windows",
-              "tags": [
-                "1.0.5-sdk-1.0.4-nanoserver",
-                "1.0.5-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
-                "1.0.5-sdk-nanoserver",
-                "1.0.5-sdk-nanoserver-$(nanoServerVersion)",
-                "1.0-sdk-nanoserver",
-                "1.0-sdk-nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "1.0.5-sdk-1.0.4-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.0.5-sdk-1.0.4-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.0.5-sdk-nanoserver": {},
+                "1.0.5-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.0-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.0-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "1.1.2-runtime-deps",
-            "1.1-runtime-deps",
-            "1-runtime-deps"
-          ],
+          "readmeOrder": 4,
+          "sharedTags": {
+            "1.1.2-runtime-deps": {},
+            "1.1-runtime-deps": {},
+            "1-runtime-deps": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.1/runtime-deps/jessie",
               "os": "linux",
-              "tags": [
-                "1.1.2-runtime-deps-jessie",
-                "1-core-deps",
-                "core-deps"
-              ]
+              "tags": {
+                "1.1.2-runtime-deps-jessie": {},
+                "1-core-deps": {
+                  "isUndocumented": true
+                },
+                "core-deps": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "1.1.2-runtime",
-            "1.1-runtime",
-            "1-runtime"
-          ],
+          "readmeOrder": 3,
+          "sharedTags": {
+            "1.1.2-runtime": {},
+            "1.1-runtime": {},
+            "1-runtime": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.1/runtime/jessie",
               "os": "linux",
-              "tags": [
-                "1.1.2-runtime-jessie",
-                "1-core",
-                "core"
-              ]
+              "tags": {
+                "1.1.2-runtime-jessie": {},
+                "1-core": {
+                  "isUndocumented": true
+                },
+                "core": {
+                  "isUndocumented": true
+                }
+              }
             },
             {
               "dockerfile": "1.1/runtime/nanoserver",
               "os": "windows",
-              "tags": [
-                "1.1.2-runtime-nanoserver",
-                "1.1.2-runtime-nanoserver-$(nanoServerVersion)",
-                "1.1-runtime-nanoserver",
-                "1.1-runtime-nanoserver-$(nanoServerVersion)",
-                "1-runtime-nanoserver",
-                "1-runtime-nanoserver-$(nanoServerVersion)",
-                "runtime-nanoserver",
-                "runtime-nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "1.1.2-runtime-nanoserver": {},
+                "1.1.2-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.1-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.1-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "1.1.2-sdk-1.0.4",
-            "1.1.2-sdk",
-            "1.1-sdk",
-            "1-sdk"
-          ],
+          "readmeOrder": 5,
+          "sharedTags": {
+            "1.1.2-sdk-1.0.4": {
+              "isUndocumented": true
+            },
+            "1.1.2-sdk": {},
+            "1.1-sdk": {},
+            "1-sdk": {}
+          },
           "platforms": [
             {
               "dockerfile": "1.1/sdk/jessie",
               "os": "linux",
-              "tags": [
-                "1.1.2-sdk-jessie"
-              ]
+              "tags": {
+                "1.1.2-sdk-jessie": {}
+              }
             },
             {
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
-              "tags": [
-                "1.1.2-sdk-1.0.4-nanoserver",
-                "1.1.2-sdk-1.0.4-nanoserver-$(nanoServerVersion)",
-                "1.1.2-sdk-nanoserver",
-                "1.1.2-sdk-nanoserver-$(nanoServerVersion)",
-                "1.1-sdk-nanoserver",
-                "1.1-sdk-nanoserver-$(nanoServerVersion)",
-                "1-sdk-nanoserver",
-                "1-sdk-nanoserver-$(nanoServerVersion)",
-                "sdk-nanoserver",
-                "sdk-nanoserver-$(nanoServerVersion)",
-                "nanoserver",
-                "nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "1.1.2-sdk-1.0.4-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.1.2-sdk-1.0.4-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.1.2-sdk-nanoserver": {},
+                "1.1.2-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1.1-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1.1-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "1-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "1-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "nanoserver": {
+                  "isUndocumented": true
+                },
+                "nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "2.0.0-runtime-deps",
-            "2.0-runtime-deps",
-            "2-runtime-deps",
-            "runtime-deps"
-          ],
+          "readmeOrder": 8,
+          "sharedTags": {
+            "2.0.0-runtime-deps": {},
+            "2.0-runtime-deps": {},
+            "2-runtime-deps": {},
+            "runtime-deps": {}
+          },
           "platforms": [
             {
               "dockerfile": "2.0/runtime-deps/stretch/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-deps-stretch"
-              ]
+              "tags": {
+                "2.0.0-runtime-deps-stretch": {}
+              }
             },
             {
               "architecture": "arm",
               "dockerfile": "2.0/runtime-deps/stretch/arm32v7",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-deps-stretch-arm32v7",
-                "2.0-runtime-deps-stretch-arm32v7",
-                "2-runtime-deps-stretch-arm32v7"
-              ],
+              "tags": {
+                "2.0.0-runtime-deps-stretch-arm32v7": {},
+                "2.0-runtime-deps-stretch-arm32v7": {
+                  "isUndocumented": true
+                },
+                "2-runtime-deps-stretch-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
               "variant": "armv7"
-             }
+            }
           ]
         },
         {
-          "sharedTags": [
-            "2.0.0-runtime",
-            "2.0-runtime",
-            "2-runtime",
-            "runtime"
-          ],
+          "readmeOrder": 6,
+          "sharedTags": {
+            "2.0.0-runtime": {},
+            "2.0-runtime": {},
+            "2-runtime": {},
+            "runtime": {}
+          },
           "platforms": [
             {
               "dockerfile": "2.0/runtime/stretch/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-stretch"
-              ]
+              "tags": {
+                "2.0.0-runtime-stretch": {}
+              }
             },
             {
               "architecture": "arm",
               "dockerfile": "2.0/runtime/stretch/arm32v7",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-stretch-arm32v7",
-                "2.0-runtime-stretch-arm32v7",
-                "2-runtime-stretch-arm32v7"
-              ],
+              "tags": {
+                "2.0.0-runtime-stretch-arm32v7": {},
+                "2.0-runtime-stretch-arm32v7": {
+                  "isUndocumented": true
+                },
+                "2-runtime-stretch-arm32v7": {
+                  "isUndocumented": true
+                }
+              },
               "variant": "armv7"
             },
             {
               "dockerfile": "2.0/runtime/nanoserver/amd64",
               "os": "windows",
-              "tags": [
-                "2.0.0-runtime-nanoserver",
-                "2.0.0-runtime-nanoserver-$(nanoServerVersion)",
-                "2.0-runtime-nanoserver",
-                "2.0-runtime-nanoserver-$(nanoServerVersion)",
-                "2-runtime-nanoserver",
-                "2-runtime-nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "2.0.0-runtime-nanoserver": {},
+                "2.0.0-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "2.0-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "2.0-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "2-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
+                "2-runtime-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "2.0.0-sdk",
-            "2.0-sdk",
-            "2-sdk",
-            "sdk",
-            "latest"
-          ],
+          "readmeOrder": 10,
+          "sharedTags": {
+            "2.0.0-sdk": {},
+            "2.0-sdk": {},
+            "2-sdk": {},
+            "sdk": {},
+            "latest": {}
+          },
           "platforms": [
             {
               "dockerfile": "2.0/sdk/stretch/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-sdk-stretch"
-              ]
+              "tags": {
+                "2.0.0-sdk-stretch": {}
+              }
             },
             {
               "dockerfile": "2.0/sdk/nanoserver/amd64",
               "os": "windows",
-              "tags": [
-                "2.0.0-sdk-nanoserver",
-                "2.0.0-sdk-nanoserver-$(nanoServerVersion)",
-                "2.0-sdk-nanoserver",
-                "2.0-sdk-nanoserver-$(nanoServerVersion)",
-                "2-sdk-nanoserver",
-                "2-sdk-nanoserver-$(nanoServerVersion)"
-              ]
+              "tags": {
+                "2.0.0-sdk-nanoserver": {},
+                "2.0.0-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "2.0-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "2.0-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                },
+                "2-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
+                "2-sdk-nanoserver-$(nanoServerVersion)": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
+          "readmeOrder": 9,
           "platforms": [
             {
               "dockerfile": "2.0/runtime-deps/jessie/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-deps-jessie",
-                "2.0-runtime-deps-jessie",
-                "2-runtime-deps-jessie"
-              ]
+              "tags": {
+                "2.0.0-runtime-deps-jessie": {},
+                "2.0-runtime-deps-jessie": {},
+                "2-runtime-deps-jessie": {}
+              }
             }
           ]
         },
         {
+          "readmeOrder": 7,
           "platforms": [
             {
               "dockerfile": "2.0/runtime/jessie/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-runtime-jessie",
-                "2.0-runtime-jessie",
-                "2-runtime-jessie"
-              ]
+              "tags": {
+                "2.0.0-runtime-jessie": {},
+                "2.0-runtime-jessie": {},
+                "2-runtime-jessie": {}
+              }
             }
           ]
         },
         {
+          "readmeOrder": 11,
           "platforms": [
             {
               "dockerfile": "2.0/sdk/jessie/amd64",
               "os": "linux",
-              "tags": [
-                "2.0.0-sdk-jessie",
-                "2.0-sdk-jessie",
-                "2-sdk-jessie"
-              ]
+              "tags": {
+                "2.0.0-sdk-jessie": {},
+                "2.0-sdk-jessie": {},
+                "2-sdk-jessie": {}
+              }
             }
           ]
         }
@@ -317,39 +429,43 @@
       "readmePath": "2.0/runtime/nanoserver-insider/README.md",
       "images": [
         {
-          "sharedTags": [
-            "2.0.0-runtime",
-            "2.0-runtime",
-            "2-runtime",
-            "runtime"
-          ],
+          "sharedTags": {
+            "2.0.0-runtime": {},
+            "2.0-runtime": {},
+            "2-runtime": {},
+            "runtime": {}
+          },
           "platforms": [
             {
               "dockerfile": "2.0/runtime/nanoserver-insider/amd64",
               "os": "windows",
-              "tags": [
-                "2.0.0-runtime-nanoserver",
-                "2.0.0-runtime-nanoserver-10.0.16237.1001"
-              ]
+              "tags": {
+                "2.0.0-runtime-nanoserver": {},
+                "2.0.0-runtime-nanoserver-10.0.16237.1001": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         },
         {
-          "sharedTags": [
-            "2.0.0-sdk",
-            "2.0-sdk",
-            "2-sdk",
-            "sdk",
-            "latest"
-          ],
+          "sharedTags": {
+            "2.0.0-sdk": {},
+            "2.0-sdk": {},
+            "2-sdk": {},
+            "sdk": {},
+            "latest": {}
+          },
           "platforms": [
             {
               "dockerfile": "2.0/sdk/nanoserver-insider/amd64",
               "os": "windows",
-              "tags": [
-                "2.0.0-sdk-nanoserver",
-                "2.0.0-sdk-nanoserver-10.0.16237.1001"
-              ]
+              "tags": {
+                "2.0.0-sdk-nanoserver": {},
+                "2.0.0-sdk-nanoserver-10.0.16237.1001": {
+                  "isUndocumented": true
+                }
+              }
             }
           ]
         }

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -27,7 +27,7 @@ function Get-RuntimeTag([string]$sdkDockerfilePath, [string]$runtimeType, [strin
     $runtimeDockerfilePath = $sdkDockerfilePath.Replace("sdk", $runtimeType)
     $platforms = Get-ActivePlatformImages $manifestRepo $activeOS |
         Where-Object { $_.Dockerfile -eq $runtimeDockerfilePath }
-    return $manifestRepo.Name + ':' + $platforms[0].Tags[0]
+    return $manifestRepo.Name + ':' + ([array]($_.Tags | ForEach-Object { $_.PSobject.Properties }))[0].Name
 }
 
 if ($UseImageCache) {
@@ -61,7 +61,7 @@ Get-ActivePlatformImages $manifestRepo $activeOS |
     Where-Object { [string]::IsNullOrEmpty($Filter) -or $_.dockerfile -like "$Filter*" } |
     Where-Object { $_.Dockerfile.Contains('sdk') } |
     ForEach-Object {
-        $sdkTag = $_.Tags[0]
+        $sdkTag = ([array]($_.Tags | ForEach-Object { $_.PSobject.Properties }))[0].Name
         $fullSdkTag = "$($manifestRepo.Name):${sdkTag}"
 
         $timeStamp = Get-Date -Format FileDateTime


### PR DESCRIPTION
As part of fixing the readme, the version of the image-builder tool was updated to the latest since it now has support for generating the tags readme documentation.  