### PR TITLE
Remove '--command' arg from builds

### DIFF
--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -125,7 +125,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170804090915"
     },
     "image-builder.args": {
-      "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -179,7 +179,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170804090915"
     },
     "image-builder.args": {
-      "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
       "allowOverride": true
     },
     "PB.docker.password": {

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -148,11 +148,11 @@
       "allowOverride": true
     },
     "image-builder.publishManifest.args": {
-      "value": "--command PublishManifest $(image-builder.common.args)",
+      "value": "publishManifest $(image-builder.common.args)",
       "allowOverride": true
     },
     "image-builder.updateReadme.args": {
-      "value": "--command UpdateReadme $(image-builder.common.args)",
+      "value": "updateReadme $(image-builder.common.args)",
       "allowOverride": true
     },
     "image-builder.containerName": {

--- a/build-pipeline/dotnet-docker-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-amd64-images.json
@@ -186,7 +186,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170804091402"
     },
     "image-builder.args": {
-      "value": "--command build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {


### PR DESCRIPTION
This change is needed with the latest image-builder as commands are now parameters.