### PR TITLE
Refactor Powershell based tests as xunit tests

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -49,6 +49,6 @@ $manifestRepo.Images |
             }
     }
 
-./test/run-test.ps1 -UseImageCache:$UseImageCache -Filter $Filter -Architecture $Architecture
+./test/run-test.ps1 -Filter $Filter -Architecture $Architecture
 
 Write-Host "Tags built and tested:`n$($builtTags | Out-String)"

--- a/test/Dockerfile.linux.publish
+++ b/test/Dockerfile.linux.publish
@@ -1,3 +1,0 @@
-FROM {image}
-
-RUN dotnet restore -r debian.8-x64 {optionalRestoreParams}

--- a/test/Dockerfile.linux.testrunner
+++ b/test/Dockerfile.linux.testrunner
@@ -12,7 +12,7 @@ RUN apt-get update \
         libcurl3 \
         libunwind8 \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -o powershell.deb -ssL https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.15/powershell_6.0.0-alpha.15-1ubuntu1.16.04.1_amd64.deb \
+RUN curl -o powershell.deb -ssL https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb \
     && dpkg -i powershell.deb \
     && rm -f powershell.deb
 

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,6 +1,0 @@
-FROM {image}
-
-WORKDIR test
-RUN dotnet new {dotnetNewParam}
-RUN dotnet restore {optionalRestoreParams}
-RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -11,9 +11,9 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public class DockerHelper
     {
-        public string DockerOS => GetDockerOS();
-        public string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
-        public bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
+        public static string DockerOS => GetDockerOS();
+        public static string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
+        public static bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
         private ITestOutputHelper Output { get; set; }
 
         public DockerHelper(ITestOutputHelper output)

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Docker.Tests
 {
     public class DockerHelper
     {
-        private string DockerOS => GetDockerOS();
+        public string DockerOS => GetDockerOS();
         public string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
         public bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
         private ITestOutputHelper Output { get; set; }
@@ -24,13 +24,13 @@ namespace Microsoft.DotNet.Docker.Tests
         public void Build(string dockerfilePath, string fromImage, string tag, string buildArgs)
         {
             string dockerfileContents = File.ReadAllText(dockerfilePath);
-            dockerfileContents = dockerfileContents.Replace("$base_image", fromImage);
+            dockerfileContents = dockerfileContents.Replace("{base_image}", fromImage);
             string tempDockerfilePath = dockerfilePath + ".temp";
             File.WriteAllText(tempDockerfilePath, dockerfileContents);
 
             try
             {
-                Execute($"build -t {tag} {buildArgs} -f {dockerfilePath} .");
+                Execute($"build -t {tag} {buildArgs} -f {tempDockerfilePath} .");
             }
             finally
             {

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -25,8 +25,8 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string dockerfileContents = File.ReadAllText(dockerfilePath);
             dockerfileContents = dockerfileContents.Replace("$base_image", fromImage);
-            dockerfilePath = dockerfilePath + ".temp";
-            File.WriteAllText(dockerfilePath, dockerfileContents);
+            string tempDockerfilePath = dockerfilePath + ".temp";
+            File.WriteAllText(tempDockerfilePath, dockerfileContents);
 
             try
             {
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
             finally
             {
-                File.Delete(dockerfilePath);
+                File.Delete(tempDockerfilePath);
             }
         }
 

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class DockerHelper
+    {
+        private string DockerOS => GetDockerOS();
+        public string ContainerWorkDir => IsLinuxContainerModeEnabled ? "/sandbox" : "c:\\sandbox";
+        public bool IsLinuxContainerModeEnabled => string.Equals(DockerOS, "linux", StringComparison.OrdinalIgnoreCase);
+        private ITestOutputHelper Output { get; set; }
+
+        public DockerHelper(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        public void Build(string dockerfilePath, string fromImage, string tag, string buildArgs)
+        {
+            string dockerfileContents = File.ReadAllText(dockerfilePath);
+            dockerfileContents = dockerfileContents.Replace("$base_image", fromImage);
+            dockerfilePath = dockerfilePath + ".temp";
+            File.WriteAllText(dockerfilePath, dockerfileContents);
+
+            try
+            {
+                Execute($"build -t {tag} {buildArgs} -f {dockerfilePath} .");
+            }
+            finally
+            {
+                File.Delete(dockerfilePath);
+            }
+        }
+
+        public void DeleteImage(string name)
+        {
+            if (ResourceExists("image", name))
+            {
+                Execute($"image rm -f {name}");
+            }
+        }
+
+        public void DeleteVolume(string name)
+        {
+            if (ResourceExists("volume", name))
+            {
+                Execute($"volume rm -f {name}");
+            }
+        }
+
+        private void Execute(string args)
+        {
+            Output.WriteLine($"Executing : docker {args}");
+            ProcessStartInfo info = new ProcessStartInfo("docker", args);
+            info.RedirectStandardOutput = true;
+            info.RedirectStandardError = true;
+            Process process = Process.Start(info);
+            process.WaitForExit();
+            Output.WriteLine(process.StandardOutput.ReadToEnd());
+
+            if (process.ExitCode != 0)
+            {
+                string stdErr = process.StandardError.ReadToEnd();
+                string msg = $"Failed to execute {info.FileName} {info.Arguments}{Environment.NewLine}{stdErr}";
+                throw new InvalidOperationException(msg);
+            }
+        }
+
+        private static string GetDockerOS()
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("docker", "version -f \"{{ .Server.Os }}\"");
+            startInfo.RedirectStandardOutput = true;
+            Process process = Process.Start(startInfo);
+            process.WaitForExit();
+            return process.StandardOutput.ReadToEnd().Trim();
+        }
+
+        public string GetContainerWorkPath(string relativePath)
+        {
+            string separator = IsLinuxContainerModeEnabled ? "/" : "\\";
+            return $"{ContainerWorkDir}{separator}{relativePath}";
+        }
+
+        private static bool ResourceExists(string type, string id)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{type} ls -q {id}");
+            startInfo.RedirectStandardOutput = true;
+            Process process = Process.Start(startInfo);
+            process.WaitForExit();
+            return process.ExitCode == 0 && process.StandardOutput.ReadToEnd().Trim() != "";
+        }
+
+        public void Run(string image, string command, string containerName, string volumeName = null)
+        {
+            string volumeArg = volumeName == null ? string.Empty : $" -v {volumeName}:{ContainerWorkDir}";
+            Execute($"run --rm --name {containerName}{volumeArg} {image} {command}");
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
@@ -1,0 +1,6 @@
+FROM $base_image
+
+ARG rid
+ARG optional_restore_feeds
+ARG optional_restore_args
+RUN dotnet restore -r $rid $optional_restore_feeds $optional_restore_args

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
@@ -1,4 +1,4 @@
-FROM $base_image
+FROM {base_image}
 
 ARG rid
 ARG optional_restore_feeds

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.publish
@@ -1,6 +1,5 @@
 FROM {base_image}
 
 ARG rid
-ARG optional_restore_feeds
 ARG optional_restore_args
-RUN dotnet restore -r $rid $optional_restore_feeds $optional_restore_args
+RUN dotnet restore -r $rid -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json $optional_restore_args

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
@@ -1,9 +1,9 @@
 FROM {base_image}
 
 ARG netcoreapp_version
-ARG optional_restore_args
+ARG optional_restore_feeds
 
 WORKDIR test
 RUN dotnet new console --framework netcoreapp$netcoreapp_version
-RUN dotnet restore $optional_restore_args
+RUN dotnet restore $optional_restore_feeds
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
@@ -1,4 +1,4 @@
-FROM $base_image
+FROM {base_image}
 
 ARG netcoreapp_version
 ARG optional_restore_args

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.linux.test
@@ -1,9 +1,8 @@
 FROM {base_image}
 
 ARG netcoreapp_version
-ARG optional_restore_feeds
 
 WORKDIR test
 RUN dotnet new console --framework netcoreapp$netcoreapp_version
-RUN dotnet restore $optional_restore_feeds
+RUN dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM $base_image
+
+ARG netcoreapp_version
+ARG optional_restore_args
+
+WORKDIR test
+RUN dotnet new console --framework netcoreapp$netcoreapp_version
+RUN dotnet restore $optional_restore_args
+RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
@@ -1,6 +1,6 @@
 FROM {base_image}
 
-ARG netcoreapp_version=2.0
+ARG netcoreapp_version
 
 WORKDIR test
 RUN dotnet new console --framework netcoreapp$env:netcoreapp_version

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
@@ -1,9 +1,8 @@
-FROM {base_image}
+FROM microsoft/dotnet-nightly:2.0-sdk
 
-ARG netcoreapp_version
-ARG optional_restore_feeds
+ARG netcoreapp_version=2.0
 
 WORKDIR test
 RUN dotnet new console --framework netcoreapp$env:netcoreapp_version
-RUN dotnet restore $env:optional_restore_feeds
+RUN dotnet restore -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
@@ -1,9 +1,9 @@
 FROM {base_image}
 
 ARG netcoreapp_version
-ARG optional_restore_args
+ARG optional_restore_feeds
 
 WORKDIR test
 RUN dotnet new console --framework netcoreapp$env:netcoreapp_version
-RUN dotnet restore $env:optional_restore_args
+RUN dotnet restore $env:optional_restore_feeds
 RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet-nightly:2.0-sdk
+FROM {base_image}
 
 ARG netcoreapp_version=2.0
 

--- a/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
+++ b/test/Microsoft.DotNet.Docker.Tests/Dockerfile.windows.test
@@ -1,0 +1,9 @@
+FROM {base_image}
+
+ARG netcoreapp_version
+ARG optional_restore_args
+
+WORKDIR test
+RUN dotnet new console --framework netcoreapp$env:netcoreapp_version
+RUN dotnet restore $env:optional_restore_args
+RUN dotnet build

--- a/test/Microsoft.DotNet.Docker.Tests/DotNetImageType.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DotNetImageType.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public enum DotNetImageType
+    {
+        SDK,
+        Runtime,
+        Runtime_Deps,
+    }
+}

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string sdkImage = GetDotNetImage(sdkImageVersion, DotNetImageType.SDK);
             string buildArgs = GetBuildArgs(usePreReleasePackageFeed, $"netcoreapp_version={netcoreappVersion}");
-            DockerHelper.Build("Dockerfile.test", sdkImage, appSdkImage, buildArgs);
+            DockerHelper.Build($"Dockerfile.{DockerHelper.DockerOS.ToLower()}.test", sdkImage, appSdkImage, buildArgs);
 
             DockerHelper.Run(appSdkImage, "dotnet run", appSdkImage);
         }
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
             if (usePreReleasePackageFeed)
             {
-                buildArgs += " --build-arg optional_restore_feeds=\"-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json\"";
+                buildArgs = "--build-arg optional_restore_feeds=\"-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json\"";
             }
 
             if (additionalArgs != null && additionalArgs.Any())

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class ImageTests
+    {
+        private DockerHelper DockerHelper { get; set; }
+
+        public ImageTests(ITestOutputHelper output)
+        {
+            DockerHelper = new DockerHelper(output);
+        }
+
+        [Fact]
+        [Trait("Version", "1.0")]
+        [Trait("Architecture", "amd64")]
+        public void VerifyImages_1_0()
+        {
+            VerifyImages("1.0");
+        }
+
+        [Fact]
+        [Trait("Version", "1.1")]
+        [Trait("Architecture", "amd64")]
+        public void VerifyImages_1_1()
+        {
+            VerifyImages("1.1");
+        }
+
+        [Fact]
+        [Trait("Version", "2.0")]
+        [Trait("Architecture", "amd64")]
+        public void VerifyImages_2_0()
+        {
+            VerifyImages("2.0", usePreReleasePackageFeed: true);
+        }
+
+        [Fact]
+        [Trait("Version", "2.1")]
+        [Trait("Architecture", "amd64")]
+        public void VerifyImages_2_1()
+        {
+            VerifyImages("2.1", "2.0", true);
+        }
+
+        private void VerifyImages(
+            string dotNetCoreImageVersion, string netcoreappVersion = null, bool usePreReleasePackageFeed = false)
+        {
+            if (netcoreappVersion == null)
+            {
+                netcoreappVersion = dotNetCoreImageVersion;
+            }
+
+            string appSdkImage = GetIdentifier(dotNetCoreImageVersion, "app-sdk");
+
+            try
+            {
+                VerifySdkImage_NewRestoreRun(appSdkImage, dotNetCoreImageVersion, netcoreappVersion, usePreReleasePackageFeed);
+                VerifyRuntimeImage_FrameworkDependentApp(dotNetCoreImageVersion, appSdkImage);
+
+                if (DockerHelper.IsLinuxContainerModeEnabled)
+                {
+                    VerifyRuntimeDepsImage_SelfContainedApp(dotNetCoreImageVersion, appSdkImage, usePreReleasePackageFeed);
+                }
+            }
+            finally
+            {
+                DockerHelper.DeleteImage(appSdkImage);
+            }
+        }
+
+        private void VerifySdkImage_NewRestoreRun(
+            string appSdkImage, string sdkImageVersion, string netcoreappVersion, bool usePreReleasePackageFeed)
+        {
+            string sdkImage = GetDotNetImage(sdkImageVersion, DotNetImageType.SDK);
+            string buildArgs = GetBuildArgs(usePreReleasePackageFeed, $"netcoreapp_version={netcoreappVersion}");
+            DockerHelper.Build("Dockerfile.test", sdkImage, appSdkImage, buildArgs);
+
+            DockerHelper.Run(appSdkImage, "dotnet run", appSdkImage);
+        }
+
+        private void VerifyRuntimeImage_FrameworkDependentApp(string runtimeImageVersion, string appSdkImage)
+        {
+            string frameworkDepAppId = GetIdentifier(runtimeImageVersion, "framework-dependent-app");
+
+            try
+            {
+                string dotNetCmd = $"dotnet publish -o {DockerHelper.ContainerWorkDir}";
+                DockerHelper.Run(appSdkImage, dotNetCmd, frameworkDepAppId, frameworkDepAppId);
+
+                string runtimeImage = GetDotNetImage(runtimeImageVersion, DotNetImageType.Runtime);
+                string appDllPath = DockerHelper.GetContainerWorkPath("test.dll");
+                DockerHelper.Run(runtimeImage, $"dotnet {appDllPath}", frameworkDepAppId, frameworkDepAppId);
+            }
+            finally
+            {
+                DockerHelper.DeleteVolume(frameworkDepAppId);
+            }
+        }
+
+        private void VerifyRuntimeDepsImage_SelfContainedApp(
+            string runtimeDepsImageVersion, string appSdkImage, bool usePreReleasePackageFeed)
+        {
+            string selfContainedAppId = GetIdentifier(runtimeDepsImageVersion, "self-contained-app");
+            string rid = "debian.8-x64";
+
+            try
+            {
+                List<string> additionalArgs = new List<string>();
+                additionalArgs.Add($"rid={rid}");
+                if (runtimeDepsImageVersion == "2.0")
+                {
+                    additionalArgs.Add($"optional_restore_args=/p:runtimeidentifier={rid}");
+                }
+
+                string buildArgs = GetBuildArgs(usePreReleasePackageFeed, additionalArgs.ToArray());
+                DockerHelper.Build("Dockerfile.linux.publish", appSdkImage, selfContainedAppId, buildArgs);
+
+                try
+                {
+                    string optionalPublishArgs = runtimeDepsImageVersion.StartsWith("1.") ? "" : "--no-restore";
+                    string dotNetCmd = $"dotnet publish -r {rid} -o {DockerHelper.ContainerWorkDir} {optionalPublishArgs}";
+                    DockerHelper.Run(selfContainedAppId, dotNetCmd, selfContainedAppId, selfContainedAppId);
+
+                    string runtimeDepsImage = GetDotNetImage(runtimeDepsImageVersion, DotNetImageType.Runtime_Deps);
+                    string appExePath = DockerHelper.GetContainerWorkPath("test");
+                    DockerHelper.Run(runtimeDepsImage, appExePath, selfContainedAppId, selfContainedAppId);
+                }
+                finally
+                {
+                    DockerHelper.DeleteVolume(selfContainedAppId);
+                }
+            }
+            finally
+            {
+                DockerHelper.DeleteImage(selfContainedAppId);
+            }
+        }
+
+        private static string GetBuildArgs(bool usePreReleasePackageFeed, params string[] additionalArgs)
+        {
+            string buildArgs = string.Empty;
+
+            if (usePreReleasePackageFeed)
+            {
+                buildArgs += " --build-arg optional_restore_feeds=\"-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json\"";
+            }
+
+            if (additionalArgs != null && additionalArgs.Any())
+            {
+                foreach (string arg in additionalArgs)
+                {
+                    buildArgs += $" --build-arg {arg}";
+                }
+            }
+
+            return buildArgs;
+        }
+
+        public static string GetDotNetImage(string imageVersion, DotNetImageType imageType)
+        {
+            string variantName = Enum.GetName(typeof(DotNetImageType), imageType).ToLowerInvariant().Replace('_', '-');
+            return $"microsoft/dotnet-nightly:{imageVersion}-{variantName}";
+        }
+
+        private static string GetIdentifier(string version, string type)
+        {
+            return $"{version}-{type}-{DateTime.Now.ToFileTime()}";
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
+++ b/test/Microsoft.DotNet.Docker.Tests/Microsoft.DotNet.Docker.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+    <ItemGroup>
+    <Content Include="Dockerfile.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -9,6 +9,9 @@ param(
     [string]$Architecture
 )
 
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
 $DotnetInstallDir = "$PSScriptRoot/../.dotnet"
 
 if (!(Test-Path "$DotnetInstallDir")) {

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -1,169 +1,62 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
 [cmdletbinding()]
 param(
-    [switch]$UseImageCache,
+    [string]$DotnetInstallDir,
     [string]$Filter,
     [string]$Architecture
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+$DotnetInstallDir = "$PSScriptRoot/../.dotnet"
 
-function Exec([scriptblock]$cmd, [string]$errorMessage = "Error executing command: " + $cmd) {
-    & $cmd
-    if ($LastExitCode -ne 0) {
-        throw $errorMessage
-    }
+if (!(Test-Path "$DotnetInstallDir")) {
+    mkdir "$DotnetInstallDir" | Out-Null
 }
 
-function Get-ActivePlatformImages([PSCustomObject]$manifestRepo, [string]$activeOS) {
-    return $manifestRepo.Images |
-        ForEach-Object { $_.Platforms } |
-        Where-Object { $_.os -eq "$activeOS" } |
-        Where-Object { ( [string]::IsNullOrEmpty($Architecture) -and -not [bool]($_.PSobject.Properties.name -match "architecture"))`
-            -or ( [bool]($_.PSobject.Properties.name -match "architecture") -and $_.architecture -eq "$Architecture" ) }
-}
-
-function Get-RuntimeTag([string]$sdkDockerfilePath, [string]$runtimeType, [string]$activeOS, [PSCustomObject]$manifestRepo) {
-    $runtimeDockerfilePath = $sdkDockerfilePath.Replace("sdk", $runtimeType)
-    $platforms = Get-ActivePlatformImages $manifestRepo $activeOS |
-        Where-Object { $_.Dockerfile -eq $runtimeDockerfilePath }
-    return $manifestRepo.Name + ':' + ([array]($_.Tags | ForEach-Object { $_.PSobject.Properties }))[0].Name
-}
-
-if ($UseImageCache) {
-    $optionalDockerBuildArgs = ""
+# Install the .NET Core SDK
+$IsRunningOnUnix = $PSVersionTable.contains("Platform") -and $PSVersionTable.Platform -eq "Unix"
+if ($IsRunningOnUnix) {
+    $DotnetInstallScript = "dotnet-install.sh"
 }
 else {
-    $optionalDockerBuildArgs = "--no-cache"
+    $DotnetInstallScript = "dotnet-install.ps1"
 }
 
-$dirSeparator = [IO.Path]::DirectorySeparatorChar
-$repoRoot = Split-Path -Parent $PSScriptRoot
-$manifestPath = [IO.Path]::combine(${repoRoot}, "manifest.json")
-$manifestRepo = (Get-Content $manifestPath | ConvertFrom-Json).Repos[0]
-$testFilesPath = "$PSScriptRoot$dirSeparator"
-$activeOS = docker version -f "{{ .Server.Os }}"
+if (!(Test-Path $DotnetInstallScript)) {
+    $DOTNET_INSTALL_SCRIPT_URL = "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/$DotnetInstallScript"
+    Invoke-WebRequest $DOTNET_INSTALL_SCRIPT_URL -OutFile $DotnetInstallDir/$DotnetInstallScript
+}
 
-# update as appropriate (e.g. "2.0-sdk") whenever pre-release packages are referenced prior to being available on NuGet.org.
-$includePrereleasePackageSourceForSdkTag = "2.*-sdk*"
-
-if ($activeOS -eq "windows") {
-    $containerRoot = "C:\"
-    $platformDirSeparator = '\'
+if ($IsRunningOnUnix) {
+    & chmod +x $DotnetInstallDir/$DotnetInstallScript
+    & $DotnetInstallDir/$DotnetInstallScript --channel "release-2.0.0" --version "2.0.0" --architecture x64 --install-dir $DotnetInstallDir
 }
 else {
-    $containerRoot = "/"
-    $platformDirSeparator = '/'
+    & $DotnetInstallDir/$DotnetInstallScript -Channel "release-2.0.0" -Version "2.0.0" -Architecture x64 -InstallDir $DotnetInstallDir
 }
 
-# Loop through each sdk Dockerfile in the repo and test the sdk and runtime images.
-Get-ActivePlatformImages $manifestRepo $activeOS |
-    Where-Object { [string]::IsNullOrEmpty($Filter) -or $_.dockerfile -like "$Filter*" } |
-    Where-Object { $_.Dockerfile.Contains('sdk') } |
-    ForEach-Object {
-        $sdkTag = ([array]($_.Tags | ForEach-Object { $_.PSobject.Properties }))[0].Name
-        $fullSdkTag = "$($manifestRepo.Name):${sdkTag}"
+if ($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
 
-        $timeStamp = Get-Date -Format FileDateTime
-        $appName = "app$timeStamp".ToLower()
-        $buildImage = "sdk-build-$appName"
+Push-Location "$PSScriptRoot\Microsoft.DotNet.Docker.Tests"
 
-        $netcoreappVersion = $sdkTag.Split('-')[0].Substring(0,3)
-        if ($sdkTag -like "2.1*-sdk*")
-        {
-            # TODO: Remove once 2.1 SDK templates support netcoreapp2.1
-            $netcoreappVersion = "2.0"
-        }
-
-        $dotnetNewParam = "console --framework netcoreapp$netcoreappVersion"
-
-        $optionalRestoreParams = ""
-        if ($sdkTag -like $includePrereleasePackageSourceForSdkTag) {
-            $optionalRestoreParams = "-s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://api.nuget.org/v3/index.json"
-        }
-
-        Write-Host "----- Testing create, restore and build with $fullSdkTag with image $buildImage -----"
-        Try {
-            exec { (Get-Content ${testFilesPath}Dockerfile.test).
-                    Replace("{image}", $fullSdkTag).
-                    Replace("{dotnetNewParam}", $dotnetNewParam).
-                    Replace("{optionalRestoreParams}", $optionalRestoreParams) `
-                | docker build $optionalDockerBuildArgs -t $buildImage -
-            }
-
-            Write-Host "----- Running app built on $fullSdkTag -----"
-            exec { docker run --rm $buildImage dotnet run }
-
-            $framworkDepVol = "framework-dep-publish-$appName"
-            Write-Host "----- Publishing framework-dependant app built on $fullSdkTag to volume $framworkDepVol -----"
-            Try {
-                exec { docker run --rm `
-                    -v ${framworkDepVol}:"${containerRoot}volume" `
-                    $buildImage `
-                    dotnet publish -o ${containerRoot}volume
-                }
-
-                $fullRuntimeTag = Get-RuntimeTag $_.Dockerfile "runtime" $activeOS $manifestRepo
-                Write-Host "----- Testing on $fullRuntimeTag with $sdkTag framework-dependent app -----"
-                exec { docker run --rm `
-                    -v ${framworkDepVol}":${containerRoot}volume" `
-                    "$fullRuntimeTag" `
-                    dotnet "${containerRoot}volume${platformDirSeparator}test.dll"
-                }
-            }
-            Finally {
-                docker volume rm $framworkDepVol
-            }
-
-            if ($activeOS -eq "linux") {
-                $selfContainedImage = "self-contained-build-${buildImage}"
-                Write-Host "----- Creating publish-image for self-contained app built on $fullSdkTag -----"
-                Try {
-                    if ($sdkTag -like "2.0-sdk*")
-                    {
-                        # Workaround for https://github.com/dotnet/sdk/issues/1570
-                        $optionalRestoreParams = " /p:runtimeidentifier=debian.8-x64"
-                    }
-
-                    exec { (Get-Content ${testFilesPath}Dockerfile.linux.publish).
-                                Replace("{image}", $buildImage).
-                                Replace("{optionalRestoreParams}", $optionalRestoreParams) `
-                        | docker build $optionalDockerBuildArgs -t $selfContainedImage -
-                    }
-
-                    $selfContainedVol = "self-contained-publish-$appName"
-                    Write-Host "----- Publishing self-contained published app built on $fullSdkTag to volume $selfContainedVol using image $selfContainedImage -----"
-                    Try {
-                        $optionalPublishParams = "--no-restore"
-                        if ($sdkTag -like "1.*-sdk*")
-                        {
-                            $optionalPublishParams=""
-                        }
-
-                        exec { docker run --rm `
-                            -v ${selfContainedVol}":${containerRoot}volume" `
-                            $selfContainedImage `
-                            dotnet publish -r debian.8-x64 -o ${containerRoot}volume $optionalPublishParams
-                        }
-
-                        $fullRuntimeDepsTag = Get-RuntimeTag $_.Dockerfile "runtime-deps" $activeOS $manifestRepo
-                        Write-Host "----- Testing $fullRuntimeDepsTag with $sdkTag self-contained app -----"
-                        exec { docker run -t --rm `
-                            -v ${selfContainedVol}":${containerRoot}volume" `
-                            $fullRuntimeDepsTag `
-                            ${containerRoot}volume${platformDirSeparator}test
-                        }
-                    }
-                    Finally {
-                        docker volume rm $selfContainedVol
-                    }
-                }
-                Finally {
-                    docker image rm $selfContainedImage
-                }
-            }
-        }
-        Finally {
-            docker image rm $buildImage
-        }
+Try {
+    # Run Tests
+    if ([string]::IsNullOrWhiteSpace($Architecture)) {
+        $Architecture = "amd64"
     }
+
+    $TestFilter = "Architecture=$Architecture"
+    if (![string]::IsNullOrWhiteSpace($Filter)) {
+        $TestFilter += "&Version=$filter"
+    }
+
+    & $DotnetInstallDir/dotnet test -v n --filter """$TestFilter"""
+
+    if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }
+}
+Finally {
+    Pop-Location
+}

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -5,7 +5,6 @@
 
 [cmdletbinding()]
 param(
-    [string]$DotnetInstallDir,
     [string]$Filter,
     [string]$Architecture
 )


### PR DESCRIPTION
The Powershell tests are just getting too complicated to maintain.  Trying xunit tests instead using C#.  This is needed as part of https://github.com/dotnet/dotnet-docker/issues/286 which requires more complicated logic to determine which sdk, runtime-deps, runtime image pairings to test together as each image will not exist for every version.