### PR TITLE
Consolidate 2.0 & 2.1 build legs on linux

### DIFF
--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -28,13 +28,7 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0"
-          }
-        },
-        {
-          "Name": "dotnet-docker-linux-amd64-images",
-          "Parameters": {
-            "PB.image-builder.path": "2.1"
+            "PB.image-builder.path": "2."
           }
         }
       ]
@@ -48,13 +42,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0"
-          }
-        },
-        {
-          "Name": "dotnet-docker-linux-arm32v7-images",
-          "Parameters": {
-            "PB.image-builder.path": "2.1"
+            "PB.image-builder.path": "2."
           }
         }
       ]

--- a/netci.groovy
+++ b/netci.groovy
@@ -4,11 +4,11 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 def platformList = ['Ubuntu16.04:Debian', 'Windows_2016:NanoServer']
-def versionList = ['1.0', '1.1', '2.0', '2.1']
 
 platformList.each { platform ->
     def(hostOS, containerOS) = platform.tokenize(':')
     def machineLabel = (hostOS == 'Windows_2016') ? 'latest-containers' : 'latest-or-auto-docker'
+    def versionList = (hostOS == 'Windows_2016') ? ['1.0', '1.1', '2.0', '2.1'] : ['1.0', '1.1', '2.']
 
     versionList.each { version ->
         def newJobName = Utilities.getFullJobName(project, "${containerOS}_${version}", isPR)

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -52,7 +52,7 @@ Try {
 
     $TestFilter = "Architecture=$Architecture"
     if (![string]::IsNullOrWhiteSpace($Filter)) {
-        $TestFilter += "&Version=$filter"
+        $TestFilter += "&Version~$filter"
     }
 
     & $DotnetInstallDir/dotnet test -v n --filter """$TestFilter"""


### PR DESCRIPTION
This is necessary in order to stop producing the 2.1-runtime-deps images since they are identical to 2.0.  The 2.1 tests will build a 2.1 self-contained app and verify it will run on the 2.0-runtime-deps image.

Related to https://github.com/dotnet/dotnet-docker/issues/286