### PR TITLE
Consolidate 1.* build legs

### DIFF
--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,13 +16,7 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.0"
-          }
-        },
-        {
-          "Name": "dotnet-docker-linux-amd64-images",
-          "Parameters": {
-            "PB.image-builder.path": "1.1"
+            "PB.image-builder.path": "1."
           }
         },
         {
@@ -56,13 +50,7 @@
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1.0"
-          }
-        },
-        {
-          "Name": "dotnet-docker-windows-amd64-images",
-          "Parameters": {
-            "PB.image-builder.path": "1.1"
+            "PB.image-builder.path": "1."
           }
         },
         {

--- a/netci.groovy
+++ b/netci.groovy
@@ -8,7 +8,7 @@ def platformList = ['Ubuntu16.04:Debian', 'Windows_2016:NanoServer']
 platformList.each { platform ->
     def(hostOS, containerOS) = platform.tokenize(':')
     def machineLabel = (hostOS == 'Windows_2016') ? 'latest-containers' : 'latest-or-auto-docker'
-    def versionList = (hostOS == 'Windows_2016') ? ['1.0', '1.1', '2.0', '2.1'] : ['1.0', '1.1', '2.']
+    def versionList = (hostOS == 'Windows_2016') ? ['1.', '2.0', '2.1'] : ['1.', '2.']
 
     versionList.each { version ->
         def newJobName = Utilities.getFullJobName(project, "${containerOS}_${version}", isPR)


### PR DESCRIPTION
This is necessary in order to consolidate the duplicated 1.* SDK Dockerfiles.  The 1.* tests will require the common 1.* SDK image to test the various runtime and runtime-deps images therefore all 1.* images must be built in the same build leg.

Related to dotnet/dotnet-docker#294