### PR TITLE
Refactor all utests to use Theory and MemberData

### DIFF
--- a/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.DotNet.Docker.Tests
 {
-    public class VerifyImageDescriptor
+    public class ImageDescriptor
     {
         private string runtimeDepsVersion;
         private string sdkVersion;

--- a/test/Microsoft.DotNet.Docker.Tests/VerifyImageDescriptor.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/VerifyImageDescriptor.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class VerifyImageDescriptor
+    {
+        private string runtimeDepsVersion;
+        private string sdkVersion;
+
+        public string Architecture { get; set; } = "amd64";
+        public string DotNetCoreVersion { get; set; }
+        public string OsVariant { get; set; }
+
+        public string RuntimeDepsVersion
+        {
+            get { return runtimeDepsVersion ?? DotNetCoreVersion; }
+            set { runtimeDepsVersion = value; }
+        }
+
+        public string SdkVersion
+        {
+            get { return sdkVersion ?? DotNetCoreVersion; }
+            set { sdkVersion = value; }
+        }
+    }
+}

--- a/test/run-test.ps1
+++ b/test/run-test.ps1
@@ -50,12 +50,10 @@ Try {
         $Architecture = "amd64"
     }
 
-    $TestFilter = "Architecture=$Architecture"
-    if (![string]::IsNullOrWhiteSpace($Filter)) {
-        $TestFilter += "&Version~$filter"
-    }
+    $env:IMAGE_ARCH_FILTER = $Architecture
+    $env:IMAGE_VERSION_FILTER = $Filter
 
-    & $DotnetInstallDir/dotnet test -v n --filter """$TestFilter"""
+    & $DotnetInstallDir/dotnet test -v n
 
     if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }
 }


### PR DESCRIPTION
This should make it easier to maintain the tests as new .NET Core versions are released and support is dropped for older versions.