### PR TITLE
Skip tests in arm build legs

### DIFF
--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -179,7 +179,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) --test-var Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --skip-test --test-var Filter=$(PB.image-builder.path) --test-var Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
       "allowOverride": true
     },
     "PB.docker.password": {


### PR DESCRIPTION
Added logic to skip arm tests since there aren't any currently defined.  This change is needed as part of https://github.com/dotnet/dotnet-docker-nightly/pull/435 because a [Theory without data is considered invalid](https://github.com/xunit/xunit/issues/1113).  This change should be reverted with https://github.com/dotnet/dotnet-docker-nightly/pull/434.