### PR TITLE
Build SDK images in ARM build leg.

### DIFF
--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -122,7 +122,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171004130549"
     },
     "image-builder.args": {
       "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --test-var Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -84,7 +84,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run image-builder",
+      "displayName": "Build SDK images (needed for testing)",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -94,7 +94,26 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run  $(docker.commonRunArgs) -v /var/run/docker.sock:/var/run/docker.sock $(image-builder.imageName) $(image-builder.args)",
+        "arguments": "$(docker.runArgs) $(image-builder.sdkArgs)",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Build ARM images",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "$(docker.runArgs) $(image-builder.args)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -166,6 +185,9 @@
     "docker.commonRunArgs": {
       "value": "--rm -v $(docker.volumeName):/repo -w /repo --name $(docker.containerName)"
     },
+    "docker.runArgs": {
+      "value": "run  $(docker.commonRunArgs) -v /var/run/docker.sock:/var/run/docker.sock $(image-builder.imageName)"
+    },
     "docker.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
@@ -176,10 +198,18 @@
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171004130549"
+    },
+    "image-builder.commonArgs": {
+      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly $(PB.image-builder.customCommonArgs)",
+      "allowOverride": true
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --architecture arm --skip-test --test-var Filter=$(PB.image-builder.path) --test-var Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",
+      "value": "$(image-builder.commonArgs) --path $(PB.image-builder.path) --architecture arm --test-var Filter=$(PB.image-builder.path) --test-var Architecture=arm --push --username $(PB.docker.username) --password $(PB.docker.password)",
+      "allowOverride": true
+    },
+    "image-builder.sdkArgs": {
+      "value": "$(image-builder.commonArgs) --path $(PB.image-builder.path)/sdk/stretch/amd64 --architecture amd64 --skip-test",
       "allowOverride": true
     },
     "PB.docker.password": {

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20170817154316"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20171004130549"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --repo microsoft/dotnet-nightly --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/dotnet-docker-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-amd64-images.json
@@ -183,7 +183,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20170818060355"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20171004130519"
     },
     "image-builder.args": {
       "value": "build --manifest manifest.json --repo microsoft/dotnet-nightly --path $(PB.image-builder.path) --test-var Filter=$(PB.image-builder.path) --test-var Architecture=amd64 --push --username $(PB.docker.username) --password $(PB.docker.password) $(PB.image-builder.customCommonArgs)",

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,13 +16,13 @@
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1."
+            "PB.image-builder.path": "1.*"
           }
         },
         {
           "Name": "dotnet-docker-linux-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2."
+            "PB.image-builder.path": "2.*"
           }
         }
       ]
@@ -36,7 +36,7 @@
         {
           "Name": "dotnet-docker-linux-arm32v7-images",
           "Parameters": {
-            "PB.image-builder.path": "2."
+            "PB.image-builder.path": "2.*"
           }
         }
       ]
@@ -50,19 +50,19 @@
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "1."
+            "PB.image-builder.path": "1.*"
           }
         },
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0"
+            "PB.image-builder.path": "2.0*"
           }
         },
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.1"
+            "PB.image-builder.path": "2.1*"
           }
         }
       ]

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -61,12 +62,18 @@ namespace Microsoft.DotNet.Docker.Tests
                     });
             }
 
+            string versionFilterPattern = null;
+            if (VersionFilter != null)
+            {
+                versionFilterPattern = Regex.Escape(VersionFilter).Replace(@"\*", ".*").Replace(@"\?", ".");
+            }
+
             // Filter out test data that does not match the active architecture and version filters.
             return testData
                 .Where(imageDescriptor => ArchFilter == null
                     || string.Equals(imageDescriptor.Architecture, ArchFilter, StringComparison.OrdinalIgnoreCase))
                 .Where(imageDescriptor => VersionFilter == null
-                    || imageDescriptor.DotNetCoreVersion.StartsWith(VersionFilter))
+                    || Regex.IsMatch(imageDescriptor.DotNetCoreVersion, versionFilterPattern, RegexOptions.IgnoreCase))
                 .Select(imageDescriptor => new object[] { imageDescriptor });
         }
 


### PR DESCRIPTION
Add a build task that builds SDK images. These images are consumed by ARM unit tests.

Updated the image names to `jessie-20171004130549` and `nanoserver-20171004130519` that include the regex support added in ImageBuilder. Refer https://github.com/dotnet/docker-tools/pull/49

Verified the changes through a test build (https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1040410&_a=summary)
