### PR TITLE
Add logic to tests to verify tested images exist

### DIFF
--- a/test/Dockerfile.linux.testrunner
+++ b/test/Dockerfile.linux.testrunner
@@ -2,17 +2,31 @@
 #     docker build -t testrunner -f ./test/Dockerfile.linux.testrunner .
 #     docker run --rm -v /var/run/docker.sock:/var/run/docker.sock testrunner powershell -File build-and-test.ps1 -UseImageCache
 
-FROM ubuntu
+FROM ubuntu:16.04
+
+# Install Docker
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        apt-transport-https \
         ca-certificates \
         curl \
-        docker.io \
+        software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Powershell
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         libicu55 \
         libcurl3 \
         libunwind8 \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl -o powershell.deb -ssL https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -o powershell.deb -ssL \
+        https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb \
     && dpkg -i powershell.deb \
     && rm -f powershell.deb
 

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -35,11 +35,11 @@ namespace Microsoft.DotNet.Docker.Tests
             Execute($"build -t {tag} {buildArgsOption} -f {dockerfile} .");
         }
 
-        public void DeleteImage(string name)
+        public void DeleteImage(string tag)
         {
-            if (ResourceExists("image", name))
+            if (ImageExists(tag))
             {
-                Execute($"image rm -f {name}");
+                Execute($"image rm -f {tag}");
             }
         }
 
@@ -97,6 +97,11 @@ namespace Microsoft.DotNet.Docker.Tests
         {
             string volumeArg = volumeName == null ? string.Empty : $" -v {volumeName}:{ContainerWorkDir}";
             Execute($"run --rm --name {containerName}{volumeArg} {image} {command}");
+        }
+
+        public static bool ImageExists(string tag)
+        {
+            return ResourceExists("image", tag);
         }
     }
 }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -230,6 +230,8 @@ namespace Microsoft.DotNet.Docker.Tests
                 imageName += $"-arm32v7";
             }
 
+            Assert.True(DockerHelper.ImageExists(imageName), $"`{imageName}` could not be found on disk.");
+
             return imageName;
         }
 


### PR DESCRIPTION
This change helps verify the integrity of CI and official builds.  If the images being tested, weren't just built, something is configured incorrectly.