### PR TITLE
Add escape directive in Nano Server Dockerfiles

### DIFF
--- a/1.0/runtime/nanoserver/Dockerfile
+++ b/1.0/runtime/nanoserver/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -6,8 +8,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV DOTNET_VERSION 1.0.7
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
-RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')

--- a/1.1/runtime/nanoserver/Dockerfile
+++ b/1.1/runtime/nanoserver/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -6,8 +8,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV DOTNET_VERSION 1.1.4
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/release/1.1.0/Binaries/$DOTNET_VERSION/dotnet-win-x64.$DOTNET_VERSION.zip
 
-RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')

--- a/1.1/sdk/nanoserver/Dockerfile
+++ b/1.1/sdk/nanoserver/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -6,16 +8,16 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ENV DOTNET_SDK_VERSION 1.1.4
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-win-x64.$DOTNET_SDK_VERSION.zip
 
-RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-RUN New-Item -Type Directory warmup; \
-    cd warmup; \
-    dotnet new; \
-    cd ..; \
+RUN New-Item -Type Directory warmup; `
+    cd warmup; `
+    dotnet new; `
+    cd ..; `
     Remove-Item -Force -Recurse warmup

--- a/2.0/runtime/nanoserver/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver/amd64/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -7,13 +9,13 @@ ENV DOTNET_VERSION 2.0.0
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-win-x64.zip
 ENV DOTNET_DOWNLOAD_SHA 7D7D0A9B03CB7BB16A2E7B97288B03EABFFB37073C2B025BB9D535CCD51E3F46DB9546A521D5719366DCB6E45529B1B8C54708CF47C619521B556F21F1FFAB59
 
-RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
-    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_DOWNLOAD_SHA) { \
-        Write-Host 'CHECKSUM VERIFICATION FAILED!'; \
-        exit 1; \
-    }; \
-    \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')

--- a/2.0/sdk/nanoserver/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver/amd64/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -7,21 +9,21 @@ ENV DOTNET_SDK_VERSION 2.0.3-servicing-007037
 ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip
 ENV DOTNET_SDK_DOWNLOAD_SHA 5A033D78E91FA2D1B74D3D40237EAB1FC16C590183E683630274C3DE4AEBE14E69929A433380FB7C690FFDC56550C529F98B8C13FEF66B89FD769A869104B6E9
 
-RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; \
-    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_SDK_DOWNLOAD_SHA) { \
-        Write-Host 'CHECKSUM VERIFICATION FAILED!'; \
-        exit 1; \
-    }; \
-    \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_SDK_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip
-RUN New-Item -Type Directory warmup; \
-    cd warmup; \
-    dotnet new; \
-    cd ..; \
+RUN New-Item -Type Directory warmup; `
+    cd warmup; `
+    dotnet new; `
+    cd ..; `
     Remove-Item -Force -Recurse warmup

--- a/2.1/runtime/nanoserver/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver/amd64/Dockerfile
@@ -1,3 +1,5 @@
+# escape=`
+
 FROM microsoft/nanoserver:10.0.14393.1770
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -7,13 +9,13 @@ ENV DOTNET_VERSION 2.1.0-preview1-25806-02
 ENV DOTNET_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/dotnet-runtime-$DOTNET_VERSION-win-x64.zip
 ENV DOTNET_DOWNLOAD_SHA 73CFF6524017CAD193D99413E627476D30CE4FE017F6DE8D7A3C6EE245FBD67D61D6F3B9E731310D2B850E723D42F33931F3D3EB9F03465DB9D61DAEA660A8F7
 
-RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; \
-    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_DOWNLOAD_SHA) { \
-        Write-Host 'CHECKSUM VERIFICATION FAILED!'; \
-        exit 1; \
-    }; \
-    \
-    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; \
+RUN Invoke-WebRequest $Env:DOTNET_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
     Remove-Item -Force dotnet.zip
 
 RUN setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')


### PR DESCRIPTION
Update Nano Server Dockerfile to use the escape directive (https://docs.docker.com/engine/reference/builder/#escape).

Tested these changes by running `build-and-test.ps1 -Filter *nanoserver*`. Tested the scope of the escape directive through the following sequence -

1. Build an image using a Dockerfile that uses backtick as the escape directive. Say, image tag is `backtick:latest`
2. Prepare a Dockerfile that uses `backtick:latest`. Add some additional commands in the Dockerfile that use `\` backslash as the line continuation character.
3. Build an image using the Dockerfile created in step #2. Expectation is a Dockerfile parse error due to `\` character.
