### PR TITLE
Set build cleanup options

### DIFF
--- a/build-pipeline/dotnet-docker-linux-amd64-images.json
+++ b/build-pipeline/dotnet-docker-linux-amd64-images.json
@@ -166,7 +166,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "0",
+      "cleanOptions": "3",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",
@@ -183,7 +183,7 @@
     "name": "dotnet/dotnet-docker-nightly",
     "url": "https://github.com/dotnet/dotnet-docker-nightly.git",
     "defaultBranch": "master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},

--- a/build-pipeline/dotnet-docker-linux-arm32v7-images.json
+++ b/build-pipeline/dotnet-docker-linux-arm32v7-images.json
@@ -248,7 +248,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "0",
+      "cleanOptions": "3",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",
@@ -265,7 +265,7 @@
     "name": "dotnet/dotnet-docker-nightly",
     "url": "https://github.com/dotnet/dotnet-docker-nightly.git",
     "defaultBranch": "master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},

--- a/build-pipeline/dotnet-docker-post-image-build.json
+++ b/build-pipeline/dotnet-docker-post-image-build.json
@@ -190,7 +190,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "0",
+      "cleanOptions": "3",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",
@@ -207,7 +207,7 @@
     "name": "dotnet/dotnet-docker-nightly",
     "url": "https://github.com/dotnet/dotnet-docker-nightly.git",
     "defaultBranch": "master",
-    "clean": "false",
+    "clean": "true",
     "checkoutSubmodules": false
   },
   "processParameters": {},

--- a/build-pipeline/dotnet-docker-windows-amd64-images.json
+++ b/build-pipeline/dotnet-docker-windows-amd64-images.json
@@ -227,7 +227,7 @@
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {
-      "cleanOptions": "1",
+      "cleanOptions": "3",
       "gitLfsSupport": "false",
       "skipSyncSource": "false",
       "reportBuildStatus": "true",


### PR DESCRIPTION
Ensures build sources and output directory is cleaned up before starting a build.

@dotnet-bot skip ci please