### PR TITLE
Add Nano Server ltsc2016 tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 
 # Supported Windows Server 2016 amd64 tags
 
-- [`1.0.7-runtime-nanoserver-ltsc2016`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/runtime/nanoserver/Dockerfile)
-- [`1.1.4-runtime-nanoserver-ltsc2016`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime/nanoserver/Dockerfile)
-- [`1.1.4-sdk-nanoserver-ltsc2016`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/nanoserver/Dockerfile)
-- [`2.0.1-runtime-nanoserver-ltsc2016`, `2.0-runtime-nanoserver-ltsc2016`, `2.0.1-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
-- [`2.0.1-sdk-2.0.3-nanoserver-ltsc2016`, `2.0-sdk-nanoserver-ltsc2016`, `2.0.1-sdk-2.0.3`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-nanoserver-ltsc2016`, `2.1-runtime-nanoserver-ltsc2016`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime/nanoserver/amd64/Dockerfile)
-- [`2.1.0-preview1-sdk-nanoserver-ltsc2016`, `2.1-sdk-nanoserver-ltsc2016`, `2.1.0-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/nanoserver/amd64/Dockerfile)
+- [`1.0.7-runtime-nanoserver-sac2016`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/runtime/nanoserver/Dockerfile)
+- [`1.1.4-runtime-nanoserver-sac2016`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime/nanoserver/Dockerfile)
+- [`1.1.4-sdk-nanoserver-sac2016`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/nanoserver/Dockerfile)
+- [`2.0.1-runtime-nanoserver-sac2016`, `2.0-runtime-nanoserver-sac2016`, `2.0.1-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
+- [`2.0.1-sdk-2.0.3-nanoserver-sac2016`, `2.0-sdk-nanoserver-sac2016`, `2.0.1-sdk-2.0.3`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-nanoserver-sac2016`, `2.1-runtime-nanoserver-sac2016`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime/nanoserver/amd64/Dockerfile)
+- [`2.1.0-preview1-sdk-nanoserver-sac2016`, `2.1-sdk-nanoserver-sac2016`, `2.1.0-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/nanoserver/amd64/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 
 # Supported Windows Server 2016 amd64 tags
 
-- [`1.0.7-runtime-nanoserver`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/runtime/nanoserver/Dockerfile)
-- [`1.1.4-runtime-nanoserver`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime/nanoserver/Dockerfile)
-- [`1.1.4-sdk-nanoserver`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/nanoserver/Dockerfile)
-- [`2.0.1-runtime-nanoserver`, `2.0-runtime-nanoserver`, `2.0.1-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
-- [`2.0.1-sdk-2.0.3-nanoserver`, `2.0-sdk-nanoserver`, `2.0.1-sdk-2.0.3`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
-- [`2.1.0-preview1-runtime-nanoserver`, `2.1-runtime-nanoserver`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime/nanoserver/amd64/Dockerfile)
-- [`2.1.0-preview1-sdk-nanoserver`, `2.1-sdk-nanoserver`, `2.1.0-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/nanoserver/amd64/Dockerfile)
+- [`1.0.7-runtime-nanoserver-ltsc2016`, `1.0.7-runtime`, `1.0-runtime` (*1.0/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.0/runtime/nanoserver/Dockerfile)
+- [`1.1.4-runtime-nanoserver-ltsc2016`, `1.1.4-runtime`, `1.1-runtime`, `1-runtime` (*1.1/runtime/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/runtime/nanoserver/Dockerfile)
+- [`1.1.4-sdk-nanoserver-ltsc2016`, `1.1.4-sdk`, `1.1-sdk`, `1-sdk` (*1.1/sdk/nanoserver/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/1.1/sdk/nanoserver/Dockerfile)
+- [`2.0.1-runtime-nanoserver-ltsc2016`, `2.0-runtime-nanoserver-ltsc2016`, `2.0.1-runtime`, `2.0-runtime`, `2-runtime`, `runtime` (*2.0/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/runtime/nanoserver/amd64/Dockerfile)
+- [`2.0.1-sdk-2.0.3-nanoserver-ltsc2016`, `2.0-sdk-nanoserver-ltsc2016`, `2.0.1-sdk-2.0.3`, `2.0-sdk`, `2-sdk`, `sdk`, `latest` (*2.0/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.0/sdk/nanoserver/amd64/Dockerfile)
+- [`2.1.0-preview1-runtime-nanoserver-ltsc2016`, `2.1-runtime-nanoserver-ltsc2016`, `2.1.0-preview1-runtime`, `2.1-runtime` (*2.1/runtime/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime/nanoserver/amd64/Dockerfile)
+- [`2.1.0-preview1-sdk-nanoserver-ltsc2016`, `2.1-sdk-nanoserver-ltsc2016`, `2.1.0-preview1-sdk`, `2.1-sdk` (*2.1/sdk/nanoserver/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/nanoserver/amd64/Dockerfile)
 
 # Supported Linux arm32 tags
 

--- a/manifest.json
+++ b/manifest.json
@@ -66,7 +66,7 @@
               "dockerfile": "1.0/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.7-runtime-nanoserver-ltsc2016": {},
+                "1.0.7-runtime-nanoserver-sac2016": {},
                 "1.0.7-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -105,7 +105,7 @@
               "dockerfile": "1.1/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-runtime-nanoserver-ltsc2016": {},
+                "1.1.4-runtime-nanoserver-sac2016": {},
                 "1.1.4-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -147,7 +147,7 @@
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-sdk-nanoserver-ltsc2016": {},
+                "1.1.4-sdk-nanoserver-sac2016": {},
                 "1.1.4-sdk-nanoserver": {
                   "isUndocumented": true
                 },
@@ -236,14 +236,14 @@
               "dockerfile": "2.0/runtime/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.1-runtime-nanoserver-ltsc2016": {},
+                "2.0.1-runtime-nanoserver-sac2016": {},
                 "2.0.1-runtime-nanoserver": {
                   "isUndocumented": true
                 },
                 "2.0.1-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-runtime-nanoserver-ltsc2016": {},
+                "2.0-runtime-nanoserver-sac2016": {},
                 "2.0-runtime-nanoserver": {
                   "isUndocumented": true
                 },
@@ -285,14 +285,14 @@
               "dockerfile": "2.0/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.1-sdk-2.0.3-nanoserver-ltsc2016": {},
+                "2.0.1-sdk-2.0.3-nanoserver-sac2016": {},
                 "2.0.1-sdk-2.0.3-nanoserver": {
                   "isUndocumented": true
                 },
                 "2.0.1-sdk-2.0.3-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-sdk-nanoserver-ltsc2016": {},
+                "2.0-sdk-nanoserver-sac2016": {},
                 "2.0-sdk-nanoserver": {
                   "isUndocumented": true
                 },
@@ -383,8 +383,8 @@
               "dockerfile": "2.1/runtime/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview1-runtime-nanoserver-ltsc2016": {},
-                "2.1-runtime-nanoserver-ltsc2016": {}
+                "2.1.0-preview1-runtime-nanoserver-sac2016": {},
+                "2.1-runtime-nanoserver-sac2016": {}
               }
             },
             {
@@ -417,8 +417,8 @@
               "dockerfile": "2.1/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview1-sdk-nanoserver-ltsc2016": {},
-                "2.1-sdk-nanoserver-ltsc2016": {}
+                "2.1.0-preview1-sdk-nanoserver-sac2016": {},
+                "2.1-sdk-nanoserver-sac2016": {}
               }
             },
             {

--- a/manifest.json
+++ b/manifest.json
@@ -66,7 +66,10 @@
               "dockerfile": "1.0/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.0.7-runtime-nanoserver": {},
+                "1.0.7-runtime-nanoserver-ltsc2016": {},
+                "1.0.7-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
                 "1.0.7-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
@@ -102,7 +105,10 @@
               "dockerfile": "1.1/runtime/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-runtime-nanoserver": {},
+                "1.1.4-runtime-nanoserver-ltsc2016": {},
+                "1.1.4-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
                 "1.1.4-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
@@ -141,7 +147,10 @@
               "dockerfile": "1.1/sdk/nanoserver",
               "os": "windows",
               "tags": {
-                "1.1.4-sdk-nanoserver": {},
+                "1.1.4-sdk-nanoserver-ltsc2016": {},
+                "1.1.4-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
                 "1.1.4-sdk-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
@@ -227,11 +236,17 @@
               "dockerfile": "2.0/runtime/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.1-runtime-nanoserver": {},
+                "2.0.1-runtime-nanoserver-ltsc2016": {},
+                "2.0.1-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
                 "2.0.1-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-runtime-nanoserver": {},
+                "2.0-runtime-nanoserver-ltsc2016": {},
+                "2.0-runtime-nanoserver": {
+                  "isUndocumented": true
+                },
                 "2-runtime-nanoserver": {
                   "isUndocumented": true
                 }
@@ -270,11 +285,17 @@
               "dockerfile": "2.0/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.0.1-sdk-2.0.3-nanoserver": {},
+                "2.0.1-sdk-2.0.3-nanoserver-ltsc2016": {},
+                "2.0.1-sdk-2.0.3-nanoserver": {
+                  "isUndocumented": true
+                },
                 "2.0.1-sdk-2.0.3-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
-                "2.0-sdk-nanoserver": {},
+                "2.0-sdk-nanoserver-ltsc2016": {},
+                "2.0-sdk-nanoserver": {
+                  "isUndocumented": true
+                },
                 "2-sdk-nanoserver": {
                   "isUndocumented": true
                 }
@@ -362,11 +383,8 @@
               "dockerfile": "2.1/runtime/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview1-runtime-nanoserver": {},
-                "2.1-runtime-nanoserver": {},
-                "2.1.0-preview1-runtime-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "2.1.0-preview1-runtime-nanoserver-ltsc2016": {},
+                "2.1-runtime-nanoserver-ltsc2016": {}
               }
             },
             {
@@ -399,11 +417,8 @@
               "dockerfile": "2.1/sdk/nanoserver/amd64",
               "os": "windows",
               "tags": {
-                "2.1.0-preview1-sdk-nanoserver": {},
-                "2.1-sdk-nanoserver": {},
-                "2.1.0-preview1-sdk-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                }
+                "2.1.0-preview1-sdk-nanoserver-ltsc2016": {},
+                "2.1-sdk-nanoserver-ltsc2016": {}
               }
             },
             {


### PR DESCRIPTION
`ltsc2016` is the new tag that is being added everywhere to identify Windows Server 2016.  All previously produced tags are maintained to prevent breaking users who have taken a dependency on them. 