### PR TITLE
Stop producing NanoServerVersion suffixed tags

### DIFF
--- a/1.0/runtime/nanoserver/Dockerfile
+++ b/1.0/runtime/nanoserver/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/1.1/runtime/nanoserver/Dockerfile
+++ b/1.1/runtime/nanoserver/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/1.1/sdk/nanoserver/Dockerfile
+++ b/1.1/sdk/nanoserver/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.0/runtime/nanoserver/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.0/sdk/nanoserver/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.1/runtime/nanoserver/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver/amd64/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/2.1/sdk/nanoserver/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:sac2016
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -42,10 +42,7 @@ $manifestRepo.Images |
                 if ([bool]($images.PSobject.Properties.name -match "sharedtags")) {
                     $tags += [array]($images.sharedtags | ForEach-Object { $_.PSobject.Properties })
                 }
-
-                $qualifiedTags = $tags | ForEach-Object {
-                    $manifestRepo.Name + ':' + $_.name.Replace('$(nanoServerVersion)', $manifest.TagVariables.NanoServerVersion)
-                }
+                $qualifiedTags = $tags | ForEach-Object { $manifestRepo.Name + ':' + $_.Name}
                 $formattedTags = $qualifiedTags -join ', '
                 Write-Host "--- Building $formattedTags from $dockerfilePath ---"
                 Invoke-Expression "docker build $optionalDockerBuildArgs -t $($qualifiedTags -join ' -t ') $dockerfilePath"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,4 @@
 {
-  "tagVariables": {
-    "nanoServerVersion": "10.0.14393.1770"
-  },
   "testCommands": {
     "linux": [
       "docker build --rm -t testrunner -f ./test/Dockerfile.linux.testrunner .",
@@ -70,9 +67,6 @@
                 "1.0.7-runtime-nanoserver": {
                   "isUndocumented": true
                 },
-                "1.0.7-runtime-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                },
                 "1.0-runtime-nanoserver": {
                   "isUndocumented": true
                 }
@@ -107,9 +101,6 @@
               "tags": {
                 "1.1.4-runtime-nanoserver-sac2016": {},
                 "1.1.4-runtime-nanoserver": {
-                  "isUndocumented": true
-                },
-                "1.1.4-runtime-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.1-runtime-nanoserver": {
@@ -149,9 +140,6 @@
               "tags": {
                 "1.1.4-sdk-nanoserver-sac2016": {},
                 "1.1.4-sdk-nanoserver": {
-                  "isUndocumented": true
-                },
-                "1.1.4-sdk-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "1.1-sdk-nanoserver": {
@@ -240,9 +228,6 @@
                 "2.0.1-runtime-nanoserver": {
                   "isUndocumented": true
                 },
-                "2.0.1-runtime-nanoserver-$(nanoServerVersion)": {
-                  "isUndocumented": true
-                },
                 "2.0-runtime-nanoserver-sac2016": {},
                 "2.0-runtime-nanoserver": {
                   "isUndocumented": true
@@ -287,9 +272,6 @@
               "tags": {
                 "2.0.1-sdk-2.0.3-nanoserver-sac2016": {},
                 "2.0.1-sdk-2.0.3-nanoserver": {
-                  "isUndocumented": true
-                },
-                "2.0.1-sdk-2.0.3-nanoserver-$(nanoServerVersion)": {
                   "isUndocumented": true
                 },
                 "2.0-sdk-nanoserver-sac2016": {},


### PR DESCRIPTION
Generating images with `nanoServerVersion` suffixed tag is not consistent with (https://hub.docker.com/r/microsoft/nanoserver/).  Produce only two variants - Semi Annual Channel (SAC) and 1709.

Refer https://github.com/dotnet/dotnet-docker/issues/328