### PR TITLE
Fix build break due to sac2016 folder refactor

### DIFF
--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -57,14 +57,14 @@
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.0*/nanoserver/*",
+            "PB.image-builder.path": "2.0*/nanoserver-sac2016/*",
             "PB.image-builder.customCommonArgs": "--test-var Filter=2.0* --test-var OS=nanoserver"
           }
         },
         {
           "Name": "dotnet-docker-windows-amd64-images",
           "Parameters": {
-            "PB.image-builder.path": "2.1*/nanoserver/*",
+            "PB.image-builder.path": "2.1*/nanoserver-sac2016/*",
             "PB.image-builder.customCommonArgs": "--test-var Filter=2.1* --test-var OS=nanoserver"
           }
         }


### PR DESCRIPTION
Fixing build break from https://github.com/dotnet/dotnet-docker-nightly/pull/486

@dotnet-bot skip ci please.

