### PR TITLE
Run as ContainerAdministrator in Nano Server Containers

### DIFF
--- a/2.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -25,4 +25,7 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator 
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser

--- a/2.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -25,7 +25,10 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -24,4 +24,7 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -24,7 +24,10 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -92,10 +92,16 @@ namespace Microsoft.DotNet.Docker.Tests
             return process.ExitCode == 0 && process.StandardOutput.ReadToEnd().Trim() != "";
         }
 
-        public void Run(string image, string command, string containerName, string volumeName = null)
+        public void Run(
+            string image,
+            string command,
+            string containerName,
+            string volumeName = null,
+            bool runAsContainerAdministrator = false)
         {
             string volumeArg = volumeName == null ? string.Empty : $" -v {volumeName}:{ContainerWorkDir}";
-            Execute($"run --rm --name {containerName}{volumeArg} {image} {command}");
+            string userArg = runAsContainerAdministrator ? " -u ContainerAdministrator" : string.Empty;
+            Execute($"run --rm --name {containerName}{volumeArg}{userArg} {image} {command}");
         }
 
         public static bool ImageExists(string tag)


### PR DESCRIPTION
In a Nano Server 1709 container the default user i.e. ContainerUser will not have access to a volume. Only the ContainerAdministrator will have access. Hence these changes execute docker run command with user as `ContainerAdministrator` in case of Nano Server 1709.

As part of this change, `dotnet.exe` path is included to PATH as a _system_ (as opposed to local) environment variable. Setting such variable require admin access.
