### PR TITLE
Add dotnet to system PATH

### DIFF
--- a/2.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -25,4 +25,7 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator 
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser

--- a/2.0/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.0/sdk/nanoserver-1709/amd64/Dockerfile
@@ -25,7 +25,10 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator 
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/2.1/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/runtime/nanoserver-1709/amd64/Dockerfile
@@ -24,4 +24,7 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator 
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser

--- a/2.1/sdk/nanoserver-1709/amd64/Dockerfile
+++ b/2.1/sdk/nanoserver-1709/amd64/Dockerfile
@@ -24,7 +24,10 @@ FROM microsoft/nanoserver:1709
 
 COPY --from=installer-env ["dotnet", "C:\\Program Files\\dotnet"]
 
-RUN setx PATH "%PATH%;C:\Program Files\dotnet"
+# In order to set system PATH, ContainerAdministrator must be used
+USER ContainerAdministrator 
+RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
+USER ContainerUser
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip


### PR DESCRIPTION
`dotnet.exe` path should be in system (as opposed to local) PATH. Setting such variable requires admin access. Since in Nano Server 1709 the default user i.e. `ContainerUser`, switch to `ContainerAdministrator` to set the system environment variable.

Related to https://github.com/dotnet/dotnet-docker/issues/344

Edit: Replaced "Fixes" as "Related To"