### PR TITLE
Specify user as ContainerAdministrator while running Nano Server 1709 unit tests

### DIFF
--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -92,10 +92,16 @@ namespace Microsoft.DotNet.Docker.Tests
             return process.ExitCode == 0 && process.StandardOutput.ReadToEnd().Trim() != "";
         }
 
-        public void Run(string image, string command, string containerName, string volumeName = null)
+        public void Run(
+            string image,
+            string command,
+            string containerName,
+            string volumeName = null,
+            bool runAsContainerAdministrator = false)
         {
             string volumeArg = volumeName == null ? string.Empty : $" -v {volumeName}:{ContainerWorkDir}";
-            Execute($"run --rm --name {containerName}{volumeArg} {image} {command}");
+            string userArg = runAsContainerAdministrator ? " -u ContainerAdministrator" : string.Empty;
+            Execute($"run --rm --name {containerName}{volumeArg}{userArg} {image} {command}");
         }
 
         public static bool ImageExists(string tag)


### PR DESCRIPTION
In a Nano Server 1709 container the default user i.e. _ContainerUser_ will not have access to a volume. Only the _ContainerAdministrator_ will have access. Hence these changes execute docker run command with user as _ContainerAdministrator_ in case of Nano Server 1709 unit tests.

These changes are required for enabling CI on Nano Server 1709. Related to https://github.com/dotnet/dotnet-docker-nightly/issues/468