### PR TITLE
[WIP] Add Alpine SDK image

### DIFF
--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 
-# Install .NET Core SDK
+# Install .NET Core SDK and dependencies
 RUN apk add --no-cache --virtual .build-deps \
     openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-alpine.3.6-x64.tar.gz \
@@ -18,3 +18,9 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
+
+RUN apk add --no-cache icu-libs
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,9 +1,13 @@
 FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 
-# Install .NET Core SDK and dependencies
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.2.0-preview1-007877
+
 RUN apk add --no-cache --virtual .build-deps \
-    openssl \
-    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-alpine.3.6-x64.tar.gz \
+        openssl \
+    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-alpine.3.6-x64.tar.gz \
+    && dotnet_sha512='75a5e582bf7bdce558c6b261abbc9e48df74aa52a326225e690f40a9948cf5fac236a21b257de14c1bbc3be99fbfc8b7aa6c1568f03ed7f699682964fd326f75' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,0 +1,20 @@
+FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
+
+# Install .NET Core SDK
+RUN apk add --no-cache --virtual .build-deps \
+    openssl \
+    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-alpine.3.6-x64.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz \
+    && apk del .build-deps
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+RUN mkdir warmup \
+    && cd warmup \
+    && dotnet new \
+    && cd .. \
+    && rm -rf warmup \
+    && rm -rf /tmp/NuGetScratch

--- a/2.1/sdk/alpine/amd64/Dockerfile
+++ b/2.1/sdk/alpine/amd64/Dockerfile
@@ -1,12 +1,12 @@
 FROM microsoft/dotnet-nightly:2.1-runtime-deps-alpine
 
 # Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.0-preview1-007877
+ENV DOTNET_SDK_VERSION 2.2.0-preview1-008004
 
 RUN apk add --no-cache --virtual .build-deps \
         openssl \
     && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-alpine.3.6-x64.tar.gz \
-    && dotnet_sha512='75a5e582bf7bdce558c6b261abbc9e48df74aa52a326225e690f40a9948cf5fac236a21b257de14c1bbc3be99fbfc8b7aa6c1568f03ed7f699682964fd326f75' \
+    && dotnet_sha512='3ebbf2e8265358d0229110050bd9ad1a3d7d9007aa20f473bf3fbce932a2cff9c1db1c2bea3115061fac4e64d35a485e76c7fd79758dbe56322f03112d36720a' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker) for images w
 - [`2.1.0-preview1-runtime-jessie`, `2.1-runtime-jessie` (*2.1/runtime/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime/jessie/amd64/Dockerfile)
 - [`2.1.0-preview1-runtime-deps-alpine`, `2.1-runtime-deps-alpine` (*2.1/runtime-deps/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/runtime-deps/alpine/amd64/Dockerfile)
 - [`2.1.0-preview1-sdk-stretch`, `2.1-sdk-stretch`, `2.1.0-preview1-sdk`, `2.1-sdk` (*2.1/sdk/stretch/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/stretch/amd64/Dockerfile)
+- [`2.1.0-preview1-sdk-alpine`, `2.1-sdk-alpine` (*2.1/sdk/alpine/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/alpine/amd64/Dockerfile)
 - [`2.1.0-preview1-sdk-jessie`, `2.1-sdk-jessie` (*2.1/sdk/jessie/amd64/Dockerfile*)](https://github.com/dotnet/dotnet-docker-nightly/blob/master/2.1/sdk/jessie/amd64/Dockerfile)
 
 # Supported Windows Server 2016 Version 1709 (Fall Creators Update) amd64 tags

--- a/manifest.json
+++ b/manifest.json
@@ -416,7 +416,7 @@
           ]
         },
         {
-          "readmeOrder": 15,
+          "readmeOrder": 16,
           "platforms": [
             {
               "dockerfile": "2.1/sdk/jessie/amd64",
@@ -450,6 +450,19 @@
               "tags": {
                 "2.1.0-preview1-runtime-alpine": {},
                 "2.1-runtime-alpine": {}
+              }
+            }
+          ]
+        },
+        {
+          "readmeOrder": 15,
+          "platforms": [
+            {
+              "dockerfile": "2.1/sdk/alpine/amd64",
+              "os": "linux",
+              "tags": {
+                "2.1.0-preview1-sdk-alpine": {},
+                "2.1-sdk-alpine": {}
               }
             }
           ]

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Docker.Tests
                 new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Stretch, SdkOsVariant = "", Architecture = "arm" },
                 new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0" },
                 new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0", OsVariant = OS.Jessie },
-                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine, SdkOsVariant = "", },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine },
                 new ImageDescriptor
                 {
                     DotNetCoreVersion = "2.1",


### PR DESCRIPTION
This PR isn't quite ready. Work items:

* [x] Update URL format (to match other images)
* [x] Add hash/checksum matching (to match other images)
* [ ] Consider globalization invariant mode support for the SDK.
* [x] Update tests appropriately to verify Alpine SDK image
* [x] Update manifest.json
* [x] Update readme

Sample I used for testing: https://github.com/dotnet/dotnet-docker-samples/tree/alpine/dotnetapp-prod

I got the image to work as expected but needed to remove invariant-mode support for the SDK. it seems like the SDK fails to run with invariant mode.

This is the error that I saw before removing globalization invariant mode / adding ICU:

```console
Step 7/11 : RUN dotnet publish -c Release -o out
 ---> Running in 0f3ff19e0e0f
Microsoft (R) Build Engine version 15.6.22.57775 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 46.27 ms for /app/dotnetapp.csproj.
/usr/share/dotnet/sdk/2.2.0-preview1-007846/Microsoft.Common.CurrentVersion.targets(2051,5): error MSB3095: Invalid argument. SafeHandle cannot be null. [/app/dotnetapp.csproj]
/usr/share/dotnet/sdk/2.2.0-preview1-007846/Microsoft.Common.CurrentVersion.targets(2051,5): error MSB3095: Parameter name: pHandle [/app/dotnetapp.csproj]
The command '/bin/sh -c dotnet publish -c Release -o out' returned a non-zero code: 1
```
