### PR TITLE
Ensure volumes get cleaned up and test data refactor

### DIFF
--- a/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/DockerHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public void DeleteVolume(string name)
         {
-            if (ResourceExists("volume", name))
+            if (VolumeExists(name))
             {
                 Execute($"volume rm -f {name}");
             }
@@ -83,9 +83,14 @@ namespace Microsoft.DotNet.Docker.Tests
             return $"{ContainerWorkDir}{separator}{relativePath}";
         }
 
-        private static bool ResourceExists(string type, string id)
+        public static bool ImageExists(string tag)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{type} ls -q {id}");
+            return ResourceExists("image", tag);
+        }
+
+        private static bool ResourceExists(string type, string filterArg)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("docker", $"{type} ls -q {filterArg}");
             startInfo.RedirectStandardOutput = true;
             Process process = Process.Start(startInfo);
             process.WaitForExit();
@@ -104,9 +109,9 @@ namespace Microsoft.DotNet.Docker.Tests
             Execute($"run --rm --name {containerName}{volumeArg}{userArg} {image} {command}");
         }
 
-        public static bool ImageExists(string tag)
+        public static bool VolumeExists(string name)
         {
-            return ResourceExists("image", tag);
+            return ResourceExists("volume", $"-f \"name={name}\"");
         }
     }
 }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageDescriptor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public string Architecture { get; set; } = "amd64";
         public string DotNetCoreVersion { get; set; }
-        public bool IsAlpine { get => String.Equals("alpine", OsVariant, StringComparison.OrdinalIgnoreCase); }
+        public bool IsAlpine { get => String.Equals(OS.Alpine, OsVariant, StringComparison.OrdinalIgnoreCase); }
         public bool IsArm { get => String.Equals("arm", Architecture, StringComparison.OrdinalIgnoreCase); }
         public string OsVariant { get; set; }
         public string PlatformOS { get; set; }

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -14,8 +14,37 @@ namespace Microsoft.DotNet.Docker.Tests
     public class ImageTests
     {
         private static string ArchFilter => Environment.GetEnvironmentVariable("IMAGE_ARCH_FILTER");
-        private static string OsFilter { get; set; } = Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
+        private static string OsFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
+
+        private static List<ImageDescriptor> LinuxTestData = new List<ImageDescriptor>
+            {
+                new ImageDescriptor { DotNetCoreVersion = "1.0", SdkVersion = "1.1" },
+                new ImageDescriptor { DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0" },
+                new ImageDescriptor { DotNetCoreVersion = "2.0" },
+                new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Jessie },
+                new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = OS.Stretch, SdkOsVariant = "", Architecture = "arm" },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0" },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0", OsVariant = OS.Jessie },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = OS.Alpine, SdkOsVariant = "", },
+                new ImageDescriptor
+                {
+                    DotNetCoreVersion = "2.1",
+                    RuntimeDepsVersion = "2.0",
+                    OsVariant = OS.Stretch,
+                    SdkOsVariant = "",
+                    Architecture = "arm"
+                },
+            };
+        private static List<ImageDescriptor> WindowsTestData = new List<ImageDescriptor>
+            {
+                new ImageDescriptor { DotNetCoreVersion = "1.0", PlatformOS = OS.NanoServerSac2016, SdkVersion = "1.1" },
+                new ImageDescriptor { DotNetCoreVersion = "1.1", PlatformOS = OS.NanoServerSac2016 },
+                new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = OS.NanoServerSac2016 },
+                new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = OS.NanoServer1709 },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", PlatformOS = OS.NanoServerSac2016 },
+                new ImageDescriptor { DotNetCoreVersion = "2.1", PlatformOS = OS.NanoServer1709 },
+            };
 
         private DockerHelper DockerHelper { get; set; }
 
@@ -26,48 +55,7 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static IEnumerable<object[]> GetVerifyImagesData()
         {
-            List<ImageDescriptor> testData;
-
-            if (DockerHelper.IsLinuxContainerModeEnabled)
-            {
-                testData = new List<ImageDescriptor>
-                {
-                    new ImageDescriptor { DotNetCoreVersion = "1.0", SdkVersion = "1.1" },
-                    new ImageDescriptor { DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.0" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.0", OsVariant = "jessie" },
-                    new ImageDescriptor
-                    {
-                        DotNetCoreVersion = "2.0",
-                        OsVariant = "stretch",
-                        SdkOsVariant = "",
-                        Architecture = "arm"
-                    },
-                    new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.1", RuntimeDepsVersion = "2.0", OsVariant = "jessie" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.1", OsVariant = "alpine", SdkOsVariant = "", },
-                    new ImageDescriptor
-                    {
-                        DotNetCoreVersion = "2.1",
-                        RuntimeDepsVersion = "2.0",
-                        OsVariant = "stretch",
-                        SdkOsVariant = "",
-                        Architecture ="arm"
-                    },
-                };
-            }
-            else
-            {
-                testData = new List<ImageDescriptor>
-                {
-                    new ImageDescriptor { DotNetCoreVersion = "1.0", PlatformOS = "nanoserver-sac2016", SdkVersion = "1.1" },
-                    new ImageDescriptor { DotNetCoreVersion = "1.1", PlatformOS = "nanoserver-sac2016" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver-sac2016" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.0", PlatformOS = "nanoserver-1709" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.1", PlatformOS = "nanoserver-sac2016" },
-                    new ImageDescriptor { DotNetCoreVersion = "2.1", PlatformOS = "nanoserver-1709" },
-                };
-            }
+            List<ImageDescriptor> testData = DockerHelper.IsLinuxContainerModeEnabled ? LinuxTestData : WindowsTestData;
 
             string versionFilterPattern = null;
             if (VersionFilter != null)

--- a/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/ImageTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Docker.Tests
         private static string OsFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
-        private static List<ImageDescriptor> LinuxTestData = new List<ImageDescriptor>
+        private static ImageDescriptor[] LinuxTestData = new ImageDescriptor[]
             {
                 new ImageDescriptor { DotNetCoreVersion = "1.0", SdkVersion = "1.1" },
                 new ImageDescriptor { DotNetCoreVersion = "1.1", RuntimeDepsVersion = "1.0" },
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Docker.Tests
                     Architecture = "arm"
                 },
             };
-        private static List<ImageDescriptor> WindowsTestData = new List<ImageDescriptor>
+        private static ImageDescriptor[] WindowsTestData = new ImageDescriptor[]
             {
                 new ImageDescriptor { DotNetCoreVersion = "1.0", PlatformOS = OS.NanoServerSac2016, SdkVersion = "1.1" },
                 new ImageDescriptor { DotNetCoreVersion = "1.1", PlatformOS = OS.NanoServerSac2016 },
@@ -55,8 +55,6 @@ namespace Microsoft.DotNet.Docker.Tests
 
         public static IEnumerable<object[]> GetVerifyImagesData()
         {
-            List<ImageDescriptor> testData = DockerHelper.IsLinuxContainerModeEnabled ? LinuxTestData : WindowsTestData;
-
             string versionFilterPattern = null;
             if (VersionFilter != null)
             {
@@ -70,7 +68,7 @@ namespace Microsoft.DotNet.Docker.Tests
             }
 
             // Filter out test data that does not match the active architecture and version filters.
-            return testData
+            return (DockerHelper.IsLinuxContainerModeEnabled ? LinuxTestData : WindowsTestData)
                 .Where(imageDescriptor => ArchFilter == null
                     || string.Equals(imageDescriptor.Architecture, ArchFilter, StringComparison.OrdinalIgnoreCase))
                 .Where(imageDescriptor => OsFilter == null

--- a/test/Microsoft.DotNet.Docker.Tests/OS.cs
+++ b/test/Microsoft.DotNet.Docker.Tests/OS.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Docker.Tests
+{
+    public class OS
+    {
+        public const string Alpine = "alpine";
+        public const string Jessie = "jessie";
+        public const string Stretch = "stretch";
+        public const string NanoServerSac2016 = "nanoserver-sac2016";
+        public const string NanoServer1709 = "nanoserver-1709";
+    }
+}


### PR DESCRIPTION
1. The logic to cleanup Docker volumes was failing.  A change was required to correctly check if the volume existed or not.
2. I refactored how the test data is declared slightly to hopefully make it easier to maintain going forward.